### PR TITLE
refactor: 神経衰弱のファイル命名規則を他ゲームと統一

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -43,14 +43,14 @@ src/
 カードをめくってペアを見つけるゲーム。
 
 ```
-GameBoard → useGame
-├── GameHeader（試行回数、タイマー、ペア数、ベストスコア）
-├── CardGrid（4x4 グリッド）
-│   └── GameCard（3D フリップ、アクセシビリティラベル）
-└── GameCompleteDialog
+ConcentrationBoard → useConcentration
+├── ConcentrationHeader（試行回数、タイマー、ペア数、ベストスコア）
+├── ConcentrationCardGrid（4x4 グリッド）
+│   └── ConcentrationCard（3D フリップ、アクセシビリティラベル）
+└── ConcentrationCompleteDialog
 ```
 
-主要ファイル: `src/types/game.ts`, `src/lib/game-reducer.ts`, `src/lib/cards.ts`, `src/lib/storage.ts`, `src/hooks/useGame.ts`
+主要ファイル: `src/types/concentration.ts`, `src/lib/concentration-reducer.ts`, `src/lib/concentration-cards.ts`, `src/lib/concentration-storage.ts`, `src/hooks/useConcentration.ts`
 
 ### ハイ＆ロー（high-and-low）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run lint` — ESLint（Next.js core-web-vitals + TypeScript ルール）
 - `npm run test:run` — テスト一括実行
 - `npm run test` — テスト（ウォッチモード）
-- 単一テスト実行: `npx vitest run src/lib/__tests__/cards.test.ts`
+- 単一テスト実行: `npx vitest run src/lib/__tests__/concentration-cards.test.ts`
 
 ## アーキテクチャ概要
 
-Next.js App Router + TypeScript で構築されたカードゲーム集。
+Next.js App Router + TypeScript で構築されたカードゲーム集。各ゲームは完全に独立したファイル群を持ち、ゲーム間でコードを共有しない（`shuffle` 等の小さなユーティリティも各ゲームに複製する）。
 
 詳細は `.claude/rules/` 配下のルールファイルを参照:
 
 - `architecture.md` — ゲーム追加パターン・ファイル構成・コンポーネントツリー・共有リソース
 - `conventions.md` — コーディング規約・デザイン要件・実装プロセス
 - `pitfalls.md` — 既知の注意点
+
+### ホーム画面へのゲーム登録
+
+`src/components/home/game-list.tsx` で以下 3 箇所を変更する:
+
+1. `games` 配列にエントリ追加（id, title, description, emoji, storageKey）
+2. `format<Game>Best()` 関数を追加
+3. `formatBestScore()` の switch に case を追加
+
+## 重要な規約（抜粋）
+
+- **コード内のコメントはすべて日本語で記述する**
+- **コミット・プッシュはユーザーの明示的な指示があるまで行わない**
+- **ライトモードのみ対応**（ダークモード非対応）
+- **データベース使用禁止**（localStorage 活用）
 
 ## スキル（カスタムスラッシュコマンド）
 

--- a/README.md
+++ b/README.md
@@ -125,23 +125,19 @@ src/
 ├── components/
 │   ├── ui/                      # shadcn/ui（自動生成）
 │   ├── home/                    # ホーム: ゲーム一覧・ベストスコア表示
-│   ├── game-board.tsx           # 神経衰弱: ゲーム盤面
-│   ├── card-grid.tsx            # 神経衰弱: カードグリッド
-│   ├── game-card.tsx            # 神経衰弱: 個別カード
-│   ├── game-header.tsx          # 神経衰弱: ヘッダー
-│   ├── game-complete-dialog.tsx # 神経衰弱: 完了モーダル
+│   ├── concentration/           # 神経衰弱: コンポーネント群
 │   ├── high-and-low/            # ハイ＆ロー: コンポーネント群
 │   ├── blackjack/               # ブラックジャック: コンポーネント群
 │   └── poker/                   # ビデオポーカー: コンポーネント群
 ├── hooks/
-│   ├── useGame.ts               # 神経衰弱: ゲームロジックフック
+│   ├── useConcentration.ts      # 神経衰弱: ゲームロジックフック
 │   ├── useHighAndLow.ts         # ハイ＆ロー: ゲームロジックフック
 │   ├── useBlackjack.ts          # ブラックジャック: ゲームロジックフック
 │   └── usePoker.ts              # ビデオポーカー: ゲームロジックフック
 ├── lib/
-│   ├── cards.ts                 # 神経衰弱: カード生成・シャッフル
-│   ├── game-reducer.ts          # 神経衰弱: Reducer
-│   ├── storage.ts               # 神経衰弱: localStorage操作
+│   ├── concentration-cards.ts   # 神経衰弱: カード生成・シャッフル
+│   ├── concentration-reducer.ts # 神経衰弱: Reducer
+│   ├── concentration-storage.ts # 神経衰弱: localStorage操作
 │   ├── high-and-low-cards.ts    # ハイ＆ロー: デッキ生成
 │   ├── high-and-low-reducer.ts  # ハイ＆ロー: Reducer
 │   ├── high-and-low-storage.ts  # ハイ＆ロー: localStorage操作
@@ -153,7 +149,7 @@ src/
 │   ├── poker-storage.ts         # ビデオポーカー: localStorage操作
 │   └── utils.ts                 # shadcn cn()
 ├── types/
-│   ├── game.ts                  # 神経衰弱: 型定義
+│   ├── concentration.ts         # 神経衰弱: 型定義
 │   ├── high-and-low.ts          # ハイ＆ロー: 型定義
 │   ├── blackjack.ts             # ブラックジャック: 型定義
 │   └── poker.ts                 # ビデオポーカー: 型定義

--- a/src/app/concentration/page.tsx
+++ b/src/app/concentration/page.tsx
@@ -1,5 +1,5 @@
-import { GameBoard } from "@/components/game-board";
+import { ConcentrationBoard } from "@/components/concentration/concentration-board";
 
 export default function ConcentrationPage() {
-  return <GameBoard />;
+  return <ConcentrationBoard />;
 }

--- a/src/components/concentration/__tests__/concentration-card.test.tsx
+++ b/src/components/concentration/__tests__/concentration-card.test.tsx
@@ -1,35 +1,35 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { GameCard } from "../game-card";
-import type { Card } from "@/types/game";
+import { ConcentrationCard } from "../concentration-card";
+import type { ConcentrationCard as ConcentrationCardType } from "@/types/concentration";
 
-describe("GameCard", () => {
-  const defaultCard: Card = { id: 0, emoji: "🍎", status: "hidden" };
+describe("ConcentrationCard", () => {
+  const defaultCard: ConcentrationCardType = { id: 0, emoji: "🍎", status: "hidden" };
 
   it("裏向きのカードを表示する", () => {
-    render(<GameCard card={defaultCard} onFlip={vi.fn()} disabled={false} />);
+    render(<ConcentrationCard card={defaultCard} onFlip={vi.fn()} disabled={false} />);
     expect(screen.getByRole("button")).toHaveAccessibleName("裏向きのカード");
   });
 
   it("クリックでonFlipが呼ばれる", async () => {
     const user = userEvent.setup();
     const onFlip = vi.fn();
-    render(<GameCard card={defaultCard} onFlip={onFlip} disabled={false} />);
+    render(<ConcentrationCard card={defaultCard} onFlip={onFlip} disabled={false} />);
     await user.click(screen.getByRole("button"));
     expect(onFlip).toHaveBeenCalledWith(0);
   });
 
   it("flipped状態の場合、絵文字がaria-labelに含まれる", () => {
-    const card: Card = { id: 0, emoji: "🍎", status: "flipped" };
-    render(<GameCard card={card} onFlip={vi.fn()} disabled={false} />);
+    const card: ConcentrationCardType = { id: 0, emoji: "🍎", status: "flipped" };
+    render(<ConcentrationCard card={card} onFlip={vi.fn()} disabled={false} />);
     expect(screen.getByRole("button")).toHaveAccessibleName("カード: 🍎");
   });
 
   it("disabled時はonFlipが呼ばれない", async () => {
     const user = userEvent.setup();
     const onFlip = vi.fn();
-    render(<GameCard card={defaultCard} onFlip={onFlip} disabled={true} />);
+    render(<ConcentrationCard card={defaultCard} onFlip={onFlip} disabled={true} />);
     await user.click(screen.getByRole("button"));
     expect(onFlip).not.toHaveBeenCalled();
   });
@@ -37,8 +37,8 @@ describe("GameCard", () => {
   it("matched状態のカードはクリックできない", async () => {
     const user = userEvent.setup();
     const onFlip = vi.fn();
-    const card: Card = { id: 0, emoji: "🍎", status: "matched" };
-    render(<GameCard card={card} onFlip={onFlip} disabled={false} />);
+    const card: ConcentrationCardType = { id: 0, emoji: "🍎", status: "matched" };
+    render(<ConcentrationCard card={card} onFlip={onFlip} disabled={false} />);
     await user.click(screen.getByRole("button"));
     expect(onFlip).not.toHaveBeenCalled();
   });

--- a/src/components/concentration/__tests__/concentration-header.test.tsx
+++ b/src/components/concentration/__tests__/concentration-header.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { GameHeader } from "../game-header";
+import { ConcentrationHeader } from "../concentration-header";
 
-describe("GameHeader", () => {
+describe("ConcentrationHeader", () => {
   const defaultProps = {
     moves: 0,
     elapsedTime: 0,
@@ -15,13 +15,13 @@ describe("GameHeader", () => {
   };
 
   it("idle状態で「ゲーム開始」ボタンを表示する", () => {
-    render(<GameHeader {...defaultProps} />);
+    render(<ConcentrationHeader {...defaultProps} />);
     expect(screen.getByText("ゲーム開始")).toBeInTheDocument();
   });
 
   it("playing状態で「やり直す」ボタンとスコアを表示する", () => {
     render(
-      <GameHeader
+      <ConcentrationHeader
         {...defaultProps}
         phase="playing"
         moves={5}
@@ -36,13 +36,13 @@ describe("GameHeader", () => {
   });
 
   it("complete状態で「もう一度遊ぶ」ボタンを表示する", () => {
-    render(<GameHeader {...defaultProps} phase="complete" />);
+    render(<ConcentrationHeader {...defaultProps} phase="complete" />);
     expect(screen.getByText("もう一度遊ぶ")).toBeInTheDocument();
   });
 
   it("ベストスコアを表示する", () => {
     render(
-      <GameHeader
+      <ConcentrationHeader
         {...defaultProps}
         bestScore={{ moves: 10, time: 45 }}
       />
@@ -53,7 +53,7 @@ describe("GameHeader", () => {
   it("ゲーム開始ボタンクリックでonStartが呼ばれる", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();
-    render(<GameHeader {...defaultProps} onStart={onStart} />);
+    render(<ConcentrationHeader {...defaultProps} onStart={onStart} />);
     await user.click(screen.getByText("ゲーム開始"));
     expect(onStart).toHaveBeenCalledTimes(1);
   });

--- a/src/components/concentration/concentration-board.tsx
+++ b/src/components/concentration/concentration-board.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useGame } from "@/hooks/useGame";
-import { GameHeader } from "./game-header";
-import { CardGrid } from "./card-grid";
-import { GameCompleteDialog } from "./game-complete-dialog";
+import { useConcentration } from "@/hooks/useConcentration";
+import { ConcentrationHeader } from "./concentration-header";
+import { ConcentrationCardGrid } from "./concentration-card-grid";
+import { ConcentrationCompleteDialog } from "./concentration-complete-dialog";
 import { cn } from "@/lib/utils";
 
 /** ゲーム全体をまとめるクライアントコンポーネント */
-export function GameBoard() {
-  const { state, bestScore, startGame, flipCard, dismissDialog } = useGame();
+export function ConcentrationBoard() {
+  const { state, bestScore, startGame, flipCard, dismissDialog } = useConcentration();
 
   // 2枚めくられている間はカード操作を無効化
   const isLocked = state.flippedIds.length >= 2;
@@ -21,7 +21,7 @@ export function GameBoard() {
       )}
     >
       <div className="w-full max-w-lg">
-        <GameHeader
+        <ConcentrationHeader
           moves={state.moves}
           elapsedTime={state.elapsedTime}
           matchedPairs={state.matchedPairs}
@@ -32,7 +32,7 @@ export function GameBoard() {
         />
 
         {state.phase !== "idle" && (
-          <CardGrid
+          <ConcentrationCardGrid
             cards={state.cards}
             onFlip={flipCard}
             disabled={isLocked}
@@ -40,7 +40,7 @@ export function GameBoard() {
         )}
       </div>
 
-      <GameCompleteDialog
+      <ConcentrationCompleteDialog
         open={state.dialogOpen}
         moves={state.moves}
         elapsedTime={state.elapsedTime}

--- a/src/components/concentration/concentration-card-grid.tsx
+++ b/src/components/concentration/concentration-card-grid.tsx
@@ -1,20 +1,20 @@
 "use client";
 
-import type { Card } from "@/types/game";
-import { GameCard } from "./game-card";
+import type { ConcentrationCard } from "@/types/concentration";
+import { ConcentrationCard as ConcentrationCardComponent } from "./concentration-card";
 
-type CardGridProps = {
-  cards: Card[];
+type ConcentrationCardGridProps = {
+  cards: ConcentrationCard[];
   onFlip: (cardId: number) => void;
   disabled: boolean;
 };
 
 /** 4x4レスポンシブカードグリッド */
-export function CardGrid({ cards, onFlip, disabled }: CardGridProps) {
+export function ConcentrationCardGrid({ cards, onFlip, disabled }: ConcentrationCardGridProps) {
   return (
     <div className="grid grid-cols-4 gap-2 sm:gap-3 md:gap-4 w-full max-w-md mx-auto">
       {cards.map((card) => (
-        <GameCard
+        <ConcentrationCardComponent
           key={card.id}
           card={card}
           onFlip={onFlip}

--- a/src/components/concentration/concentration-card.tsx
+++ b/src/components/concentration/concentration-card.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import type { Card } from "@/types/game";
+import type { ConcentrationCard as ConcentrationCardType } from "@/types/concentration";
 import { cn } from "@/lib/utils";
 
-type GameCardProps = {
-  card: Card;
+type ConcentrationCardProps = {
+  card: ConcentrationCardType;
   onFlip: (cardId: number) => void;
   disabled: boolean;
 };
 
 /** 3Dフリップアニメーション付きカードコンポーネント */
-export function GameCard({ card, onFlip, disabled }: GameCardProps) {
+export function ConcentrationCard({ card, onFlip, disabled }: ConcentrationCardProps) {
   const isRevealed = card.status === "flipped" || card.status === "matched";
   const isClickable = card.status === "hidden" && !disabled;
 

--- a/src/components/concentration/concentration-complete-dialog.tsx
+++ b/src/components/concentration/concentration-complete-dialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
-type GameCompleteDialogProps = {
+type ConcentrationCompleteDialogProps = {
   open: boolean;
   moves: number;
   elapsedTime: number;
@@ -26,14 +26,14 @@ function formatTime(seconds: number): string {
 }
 
 /** ゲーム完了モーダル */
-export function GameCompleteDialog({
+export function ConcentrationCompleteDialog({
   open,
   moves,
   elapsedTime,
   isNewBest,
   onPlayAgain,
   onClose,
-}: GameCompleteDialogProps) {
+}: ConcentrationCompleteDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <DialogContent className="sm:max-w-md rounded-2xl" aria-describedby="game-complete-description">

--- a/src/components/concentration/concentration-header.tsx
+++ b/src/components/concentration/concentration-header.tsx
@@ -4,15 +4,15 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import type { GamePhase, BestScore } from "@/types/game";
+import type { ConcentrationPhase, ConcentrationBestScore } from "@/types/concentration";
 
-type GameHeaderProps = {
+type ConcentrationHeaderProps = {
   moves: number;
   elapsedTime: number;
   matchedPairs: number;
   totalPairs: number;
-  phase: GamePhase;
-  bestScore: BestScore | null;
+  phase: ConcentrationPhase;
+  bestScore: ConcentrationBestScore | null;
   onStart: () => void;
 };
 
@@ -24,7 +24,7 @@ function formatTime(seconds: number): string {
 }
 
 /** ゲームヘッダー（スコア・タイマー・操作ボタン） */
-export function GameHeader({
+export function ConcentrationHeader({
   moves,
   elapsedTime,
   matchedPairs,
@@ -32,7 +32,7 @@ export function GameHeader({
   phase,
   bestScore,
   onStart,
-}: GameHeaderProps) {
+}: ConcentrationHeaderProps) {
   return (
     <div className="glass rounded-2xl p-4 sm:p-6 shadow-lg mb-4 sm:mb-6">
       {/* タイトル */}

--- a/src/components/home/game-list.tsx
+++ b/src/components/home/game-list.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useSyncExternalStore } from "react";
 
-import type { BestScore } from "@/types/game";
+import type { ConcentrationBestScore } from "@/types/concentration";
 import type { HighAndLowBestScore } from "@/types/high-and-low";
 import type { BlackjackBestScore } from "@/types/blackjack";
 import type { PokerBestScore } from "@/types/poker";
@@ -43,7 +43,7 @@ const games = [
 /** 神経衰弱のベストスコアをフォーマット */
 function formatConcentrationBest(data: string): string | null {
   try {
-    const best = JSON.parse(data) as BestScore;
+    const best = JSON.parse(data) as ConcentrationBestScore;
     return `${best.moves}回 / ${best.time}秒`;
   } catch {
     return null;

--- a/src/hooks/useConcentration.ts
+++ b/src/hooks/useConcentration.ts
@@ -1,14 +1,14 @@
 "use client";
 
 import { useReducer, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
-import { gameReducer, initialGameState } from "@/lib/game-reducer";
-import { createCards } from "@/lib/cards";
-import { getBestScore, updateBestScore } from "@/lib/storage";
-import type { BestScore, GamePhase } from "@/types/game";
+import { concentrationReducer, initialConcentrationState } from "@/lib/concentration-reducer";
+import { createCards } from "@/lib/concentration-cards";
+import { getBestScore, updateBestScore } from "@/lib/concentration-storage";
+import type { ConcentrationBestScore, ConcentrationPhase } from "@/types/concentration";
 
 /** localStorageのベストスコアを購読するストア（キャッシュ付き） */
 let bestScoreListeners: Array<() => void> = [];
-let cachedBestScore: BestScore | null = null;
+let cachedBestScore: ConcentrationBestScore | null = null;
 let cacheInitialized = false;
 
 function subscribeBestScore(callback: () => void) {
@@ -19,7 +19,7 @@ function subscribeBestScore(callback: () => void) {
 }
 
 /** キャッシュ済みのスナップショットを返す（参照安定） */
-function getSnapshotBestScore(): BestScore | null {
+function getSnapshotBestScore(): ConcentrationBestScore | null {
   if (!cacheInitialized) {
     cachedBestScore = getBestScore();
     cacheInitialized = true;
@@ -27,7 +27,7 @@ function getSnapshotBestScore(): BestScore | null {
   return cachedBestScore;
 }
 
-function getServerSnapshotBestScore(): BestScore | null {
+function getServerSnapshotBestScore(): ConcentrationBestScore | null {
   return null;
 }
 
@@ -38,9 +38,9 @@ function notifyBestScoreChange() {
 }
 
 /** ゲーム全体のロジックを管理するカスタムフック */
-export function useGame() {
-  const [state, dispatch] = useReducer(gameReducer, initialGameState);
-  const prevPhaseRef = useRef<GamePhase>("idle");
+export function useConcentration() {
+  const [state, dispatch] = useReducer(concentrationReducer, initialConcentrationState);
+  const prevPhaseRef = useRef<ConcentrationPhase>("idle");
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // useSyncExternalStoreでlocalStorageのベストスコアを購読

--- a/src/lib/__tests__/concentration-cards.test.ts
+++ b/src/lib/__tests__/concentration-cards.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shuffle, createCards, TOTAL_PAIRS } from "../cards";
+import { shuffle, createCards, TOTAL_PAIRS } from "../concentration-cards";
 
 describe("shuffle", () => {
   it("配列の長さを変えない", () => {

--- a/src/lib/__tests__/concentration-reducer.test.ts
+++ b/src/lib/__tests__/concentration-reducer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { gameReducer, initialGameState } from "../game-reducer";
-import type { Card, GameState } from "@/types/game";
+import { concentrationReducer, initialConcentrationState } from "../concentration-reducer";
+import type { ConcentrationCard, ConcentrationState } from "@/types/concentration";
 
 /** テスト用のカード配列を作成する */
-function createTestCards(): Card[] {
+function createTestCards(): ConcentrationCard[] {
   return [
     { id: 0, emoji: "🍎", status: "hidden" },
     { id: 1, emoji: "🍎", status: "hidden" },
@@ -13,9 +13,9 @@ function createTestCards(): Card[] {
 }
 
 /** テスト用のゲーム状態を作成する */
-function createPlayingState(overrides?: Partial<GameState>): GameState {
+function createPlayingState(overrides?: Partial<ConcentrationState>): ConcentrationState {
   return {
-    ...initialGameState,
+    ...initialConcentrationState,
     cards: createTestCards(),
     phase: "playing",
     totalPairs: 2,
@@ -23,11 +23,11 @@ function createPlayingState(overrides?: Partial<GameState>): GameState {
   };
 }
 
-describe("gameReducer", () => {
+describe("concentrationReducer", () => {
   describe("START_GAME", () => {
     it("カードをセットしてplaying状態にする", () => {
       const cards = createTestCards();
-      const state = gameReducer(initialGameState, {
+      const state = concentrationReducer(initialConcentrationState, {
         type: "START_GAME",
         cards,
       });
@@ -41,7 +41,7 @@ describe("gameReducer", () => {
   describe("FLIP_CARD", () => {
     it("hidden状態のカードをflippedにする", () => {
       const state = createPlayingState();
-      const next = gameReducer(state, { type: "FLIP_CARD", cardId: 0 });
+      const next = concentrationReducer(state, { type: "FLIP_CARD", cardId: 0 });
       expect(next.cards[0].status).toBe("flipped");
       expect(next.flippedIds).toEqual([0]);
     });
@@ -54,7 +54,7 @@ describe("gameReducer", () => {
         ],
         flippedIds: [0],
       });
-      const next = gameReducer(state, { type: "FLIP_CARD", cardId: 0 });
+      const next = concentrationReducer(state, { type: "FLIP_CARD", cardId: 0 });
       expect(next.flippedIds).toEqual([0]);
     });
 
@@ -62,13 +62,13 @@ describe("gameReducer", () => {
       const state = createPlayingState({
         flippedIds: [0, 2],
       });
-      const next = gameReducer(state, { type: "FLIP_CARD", cardId: 1 });
+      const next = concentrationReducer(state, { type: "FLIP_CARD", cardId: 1 });
       expect(next.flippedIds).toEqual([0, 2]);
     });
 
     it("idle状態では無視する", () => {
       const state = { ...createPlayingState(), phase: "idle" as const };
-      const next = gameReducer(state, { type: "FLIP_CARD", cardId: 0 });
+      const next = concentrationReducer(state, { type: "FLIP_CARD", cardId: 0 });
       expect(next.flippedIds).toEqual([]);
     });
   });
@@ -85,7 +85,7 @@ describe("gameReducer", () => {
         flippedIds: [0, 1],
       });
 
-      const next = gameReducer(state, { type: "CHECK_MATCH" });
+      const next = concentrationReducer(state, { type: "CHECK_MATCH" });
       expect(next.cards[0].status).toBe("matched");
       expect(next.cards[1].status).toBe("matched");
       expect(next.matchedPairs).toBe(1);
@@ -104,7 +104,7 @@ describe("gameReducer", () => {
         flippedIds: [0, 2],
       });
 
-      const next = gameReducer(state, { type: "CHECK_MATCH" });
+      const next = concentrationReducer(state, { type: "CHECK_MATCH" });
       expect(next.cards[0].status).toBe("hidden");
       expect(next.cards[1].status).toBe("hidden");
       expect(next.matchedPairs).toBe(0);
@@ -123,7 +123,7 @@ describe("gameReducer", () => {
         matchedPairs: 1,
       });
 
-      const next = gameReducer(state, { type: "CHECK_MATCH" });
+      const next = concentrationReducer(state, { type: "CHECK_MATCH" });
       expect(next.phase).toBe("complete");
       expect(next.matchedPairs).toBe(2);
       expect(next.dialogOpen).toBe(true);
@@ -133,13 +133,13 @@ describe("gameReducer", () => {
   describe("TICK", () => {
     it("playing中は経過時間を+1する", () => {
       const state = createPlayingState({ elapsedTime: 5 });
-      const next = gameReducer(state, { type: "TICK" });
+      const next = concentrationReducer(state, { type: "TICK" });
       expect(next.elapsedTime).toBe(6);
     });
 
     it("idle状態では変化しない", () => {
-      const state = { ...initialGameState, elapsedTime: 0 };
-      const next = gameReducer(state, { type: "TICK" });
+      const state = { ...initialConcentrationState, elapsedTime: 0 };
+      const next = concentrationReducer(state, { type: "TICK" });
       expect(next.elapsedTime).toBe(0);
     });
   });
@@ -152,7 +152,7 @@ describe("gameReducer", () => {
         moves: 5,
         matchedPairs: 2,
       });
-      const next = gameReducer(state, { type: "DISMISS_DIALOG" });
+      const next = concentrationReducer(state, { type: "DISMISS_DIALOG" });
       expect(next.dialogOpen).toBe(false);
       expect(next.phase).toBe("complete");
       expect(next.moves).toBe(5);
@@ -162,7 +162,7 @@ describe("gameReducer", () => {
   describe("SET_NEW_BEST", () => {
     it("isNewBestフラグを更新する", () => {
       const state = createPlayingState();
-      const next = gameReducer(state, { type: "SET_NEW_BEST", isNewBest: true });
+      const next = concentrationReducer(state, { type: "SET_NEW_BEST", isNewBest: true });
       expect(next.isNewBest).toBe(true);
     });
   });
@@ -170,8 +170,8 @@ describe("gameReducer", () => {
   describe("RESET", () => {
     it("初期状態に戻す", () => {
       const state = createPlayingState({ moves: 10, elapsedTime: 30 });
-      const next = gameReducer(state, { type: "RESET" });
-      expect(next).toEqual(initialGameState);
+      const next = concentrationReducer(state, { type: "RESET" });
+      expect(next).toEqual(initialConcentrationState);
     });
   });
 });

--- a/src/lib/__tests__/concentration-storage.test.ts
+++ b/src/lib/__tests__/concentration-storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getBestScore, saveBestScore, updateBestScore } from "../storage";
+import { getBestScore, saveBestScore, updateBestScore } from "../concentration-storage";
 
 /** localStorageのモックを作成する */
 function createLocalStorageMock() {

--- a/src/lib/concentration-cards.ts
+++ b/src/lib/concentration-cards.ts
@@ -1,4 +1,4 @@
-import type { Card } from "@/types/game";
+import type { ConcentrationCard } from "@/types/concentration";
 
 /** ゲームに使用する絵文字一覧 */
 const EMOJIS = ["🍎", "🌸", "🐬", "🌙", "⭐", "🎵", "💎", "🔥"];
@@ -20,7 +20,7 @@ export function shuffle<T>(array: T[]): T[] {
  * ゲーム用のカード配列を生成する
  * 各絵文字が2枚ずつ、シャッフルされた状態で返す
  */
-export function createCards(): Card[] {
+export function createCards(): ConcentrationCard[] {
   const pairs = EMOJIS.flatMap((emoji, index) => [
     { id: index * 2, emoji, status: "hidden" as const },
     { id: index * 2 + 1, emoji, status: "hidden" as const },

--- a/src/lib/concentration-reducer.ts
+++ b/src/lib/concentration-reducer.ts
@@ -1,8 +1,8 @@
-import type { GameState, GameAction } from "@/types/game";
-import { TOTAL_PAIRS } from "./cards";
+import type { ConcentrationState, ConcentrationAction } from "@/types/concentration";
+import { TOTAL_PAIRS } from "./concentration-cards";
 
 /** ゲーム状態の初期値 */
-export const initialGameState: GameState = {
+export const initialConcentrationState: ConcentrationState = {
   cards: [],
   flippedIds: [],
   moves: 0,
@@ -15,11 +15,11 @@ export const initialGameState: GameState = {
 };
 
 /** ゲーム状態を管理する純粋なReducer */
-export function gameReducer(state: GameState, action: GameAction): GameState {
+export function concentrationReducer(state: ConcentrationState, action: ConcentrationAction): ConcentrationState {
   switch (action.type) {
     case "START_GAME":
       return {
-        ...initialGameState,
+        ...initialConcentrationState,
         cards: action.cards,
         phase: "playing",
       };
@@ -91,7 +91,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return { ...state, dialogOpen: false };
 
     case "RESET":
-      return initialGameState;
+      return initialConcentrationState;
 
     default:
       return state;

--- a/src/lib/concentration-storage.ts
+++ b/src/lib/concentration-storage.ts
@@ -1,21 +1,21 @@
-import type { BestScore } from "@/types/game";
+import type { ConcentrationBestScore } from "@/types/concentration";
 
 const STORAGE_KEY = "concentration-best-score";
 
 /** ベストスコアをlocalStorageから取得する */
-export function getBestScore(): BestScore | null {
+export function getBestScore(): ConcentrationBestScore | null {
   if (typeof window === "undefined") return null;
   try {
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) return null;
-    return JSON.parse(data) as BestScore;
+    return JSON.parse(data) as ConcentrationBestScore;
   } catch {
     return null;
   }
 }
 
 /** ベストスコアをlocalStorageに保存する */
-export function saveBestScore(score: BestScore): void {
+export function saveBestScore(score: ConcentrationBestScore): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(score));

--- a/src/types/concentration.ts
+++ b/src/types/concentration.ts
@@ -1,23 +1,23 @@
 /** カードの状態 */
-export type CardStatus = "hidden" | "flipped" | "matched";
+export type ConcentrationCardStatus = "hidden" | "flipped" | "matched";
 
 /** カード1枚の型 */
-export type Card = {
+export type ConcentrationCard = {
   /** 一意のID */
   id: number;
   /** 絵文字（ペアのマッチングに使用） */
   emoji: string;
   /** カードの現在の状態 */
-  status: CardStatus;
+  status: ConcentrationCardStatus;
 };
 
 /** ゲームのフェーズ */
-export type GamePhase = "idle" | "playing" | "complete";
+export type ConcentrationPhase = "idle" | "playing" | "complete";
 
 /** ゲームの状態 */
-export type GameState = {
+export type ConcentrationState = {
   /** カードの配列 */
-  cards: Card[];
+  cards: ConcentrationCard[];
   /** 現在めくられているカードのID（最大2枚） */
   flippedIds: number[];
   /** 試行回数 */
@@ -27,7 +27,7 @@ export type GameState = {
   /** 総ペア数 */
   totalPairs: number;
   /** ゲームのフェーズ */
-  phase: GamePhase;
+  phase: ConcentrationPhase;
   /** 経過時間（秒） */
   elapsedTime: number;
   /** ベストスコアを更新したか */
@@ -37,7 +37,7 @@ export type GameState = {
 };
 
 /** ベストスコア */
-export type BestScore = {
+export type ConcentrationBestScore = {
   /** 最少試行回数 */
   moves: number;
   /** 最短時間（秒） */
@@ -45,8 +45,8 @@ export type BestScore = {
 };
 
 /** Reducerアクション */
-export type GameAction =
-  | { type: "START_GAME"; cards: Card[] }
+export type ConcentrationAction =
+  | { type: "START_GAME"; cards: ConcentrationCard[] }
   | { type: "FLIP_CARD"; cardId: number }
   | { type: "CHECK_MATCH" }
   | { type: "TICK" }


### PR DESCRIPTION
神経衰弱（concentration）は最初に実装されたゲームのため、ファイル名・型名にゲーム名プレフィックスがなかった。 他の全ゲーム（high-and-low, blackjack, poker）と同じ `<game>-` プレフィックス付き命名規則に統一する。

- ファイルリネーム: types/game.ts → types/concentration.ts 等（15ファイル）
- 型名リネーム: GameState → ConcentrationState, BestScore → ConcentrationBestScore 等
- コンポーネントを components/concentration/ ディレクトリに移動
- CLAUDE.md, architecture.md, README.md のドキュメント更新