### PR TITLE
ci: CIジョブ名をciからbuildにリネーム

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  ci:
+  build:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
GitHub Actions の表示を「CI / ci」から「CI / build」に改善。