### PR TITLE
fix: Issueテンプレートが表示されない不具合を修正

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
 name: Bug
-description: 不具合の報告
+about: 不具合の報告
 labels: ["bug"]
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,6 @@
 ---
 name: Documentation
-description: ルール変更・設定・ドキュメントの更新
+about: ルール変更・設定・ドキュメントの更新
 labels: ["documentation"]
 ---
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,6 @@
 ---
 name: Enhancement
-description: 新機能・改善の提案
+about: 新機能・改善の提案
 labels: ["enhancement"]
 ---
 


### PR DESCRIPTION
## Summary
- `.md`形式のIssueテンプレートで`description`フィールドを使用していたため、GitHubが"About can't be blank"エラーを出してテンプレートが表示されなかった
- 3つのテンプレート（bug, enhancement, documentation）の`description`を`about`に修正

## Test plan
- [ ] GitHubリポジトリで「New Issue」をクリックし、3つのテンプレートが表示されることを確認
- [ ] 各テンプレートを選択してIssue作成画面が正しく表示されることを確認

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)