### PR TITLE
feat: PostToolUse hookによる自動ESLintチェック

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | xargs npx eslint --no-warn-ignored 2>&1 || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Claude Code の Edit/Write ツール使用後に、編集対象ファイルの ESLint を自動実行する PostToolUse hook を追加
- lint エラーが混入したまま commit & push されるリスクを軽減

Closes #40

## Test plan

- [x] 意図的に lint エラーを含む編集を行い、`<new-diagnostics>` として Claude にエラーが通知されることを確認
- [x] 編集対象ファイルのみが診断対象であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)