### PR TITLE
feat: PreToolUse hookによるpackage-lock.json編集ブロック

### DIFF
--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# PreToolUse hook: 保護対象ファイルの編集をブロックする
+# package-lock.json は npm install/update で自動生成されるため、直接編集を禁止する
+
+FILE_PATH=$(jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+case "$FILE_PATH" in
+  */package-lock.json|package-lock.json)
+    echo "ブロック: package-lock.json は直接編集できません。npm install/update コマンドを使用してください" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
## Summary

- `package-lock.json` の直接編集（Edit/Write）を PreToolUse hook でブロック
- `npm install`/`npm update` 等の Bash 経由の操作は影響なし
- 当初は複数ファイルを保護対象としていたが、検討の結果 `package-lock.json` のみに絞った

Closes #41

## Test plan

- [ ] Claude Code で `package-lock.json` の編集を試み、ブロックされることを確認
- [ ] 保護対象外のファイル（例: `src/` 配下）が通常通り編集できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)