### PR TITLE
refactor: concentration の Storage 関数名を命名規則に統一

### DIFF
--- a/src/hooks/useConcentration.ts
+++ b/src/hooks/useConcentration.ts
@@ -3,7 +3,7 @@
 import { useReducer, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
 import { concentrationReducer, initialConcentrationState } from "@/lib/concentration-reducer";
 import { createCards } from "@/lib/concentration-cards";
-import { getBestScore, updateBestScore } from "@/lib/concentration-storage";
+import { getConcentrationBestScore, updateConcentrationBestScore } from "@/lib/concentration-storage";
 import type { ConcentrationBestScore, ConcentrationPhase } from "@/types/concentration";
 
 /** localStorageのベストスコアを購読するストア（キャッシュ付き） */
@@ -21,7 +21,7 @@ function subscribeBestScore(callback: () => void) {
 /** キャッシュ済みのスナップショットを返す（参照安定） */
 function getSnapshotBestScore(): ConcentrationBestScore | null {
   if (!cacheInitialized) {
-    cachedBestScore = getBestScore();
+    cachedBestScore = getConcentrationBestScore();
     cacheInitialized = true;
   }
   return cachedBestScore;
@@ -33,7 +33,7 @@ function getServerSnapshotBestScore(): ConcentrationBestScore | null {
 
 /** キャッシュを更新してリスナーに通知する */
 function notifyBestScoreChange() {
-  cachedBestScore = getBestScore();
+  cachedBestScore = getConcentrationBestScore();
   bestScoreListeners.forEach((l) => l());
 }
 
@@ -53,7 +53,7 @@ export function useConcentration() {
   // ゲーム完了時のベストスコア更新
   useEffect(() => {
     if (state.phase === "complete" && prevPhaseRef.current !== "complete") {
-      const updated = updateBestScore(state.moves, state.elapsedTime);
+      const updated = updateConcentrationBestScore(state.moves, state.elapsedTime);
       dispatch({ type: "SET_NEW_BEST", isNewBest: updated });
       if (updated) {
         notifyBestScoreChange();

--- a/src/lib/__tests__/concentration-storage.test.ts
+++ b/src/lib/__tests__/concentration-storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getBestScore, saveBestScore, updateBestScore } from "../concentration-storage";
+import { getConcentrationBestScore, saveConcentrationBestScore, updateConcentrationBestScore } from "../concentration-storage";
 
 /** localStorageのモックを作成する */
 function createLocalStorageMock() {
@@ -34,9 +34,9 @@ describe("storage", () => {
     });
   });
 
-  describe("getBestScore", () => {
+  describe("getConcentrationBestScore", () => {
     it("データがない場合はnullを返す", () => {
-      expect(getBestScore()).toBeNull();
+      expect(getConcentrationBestScore()).toBeNull();
     });
 
     it("保存されたスコアを取得する", () => {
@@ -44,18 +44,18 @@ describe("storage", () => {
         "concentration-best-score",
         JSON.stringify({ moves: 10, time: 30 })
       );
-      expect(getBestScore()).toEqual({ moves: 10, time: 30 });
+      expect(getConcentrationBestScore()).toEqual({ moves: 10, time: 30 });
     });
 
     it("不正なJSONの場合はnullを返す", () => {
       mockStorage.setItem("concentration-best-score", "invalid");
-      expect(getBestScore()).toBeNull();
+      expect(getConcentrationBestScore()).toBeNull();
     });
   });
 
-  describe("saveBestScore", () => {
+  describe("saveConcentrationBestScore", () => {
     it("スコアをlocalStorageに保存する", () => {
-      saveBestScore({ moves: 8, time: 25 });
+      saveConcentrationBestScore({ moves: 8, time: 25 });
       const stored = JSON.parse(
         mockStorage.getItem("concentration-best-score")!
       );
@@ -63,32 +63,32 @@ describe("storage", () => {
     });
   });
 
-  describe("updateBestScore", () => {
+  describe("updateConcentrationBestScore", () => {
     it("初回は常に保存してtrueを返す", () => {
-      const result = updateBestScore(10, 30);
+      const result = updateConcentrationBestScore(10, 30);
       expect(result).toBe(true);
-      expect(getBestScore()).toEqual({ moves: 10, time: 30 });
+      expect(getConcentrationBestScore()).toEqual({ moves: 10, time: 30 });
     });
 
     it("試行回数が少ない場合は更新する", () => {
-      saveBestScore({ moves: 10, time: 30 });
-      const result = updateBestScore(8, 40);
+      saveConcentrationBestScore({ moves: 10, time: 30 });
+      const result = updateConcentrationBestScore(8, 40);
       expect(result).toBe(true);
-      expect(getBestScore()?.moves).toBe(8);
+      expect(getConcentrationBestScore()?.moves).toBe(8);
     });
 
     it("同じ試行回数で時間が短い場合は更新する", () => {
-      saveBestScore({ moves: 10, time: 30 });
-      const result = updateBestScore(10, 25);
+      saveConcentrationBestScore({ moves: 10, time: 30 });
+      const result = updateConcentrationBestScore(10, 25);
       expect(result).toBe(true);
-      expect(getBestScore()?.time).toBe(25);
+      expect(getConcentrationBestScore()?.time).toBe(25);
     });
 
     it("スコアが劣る場合は更新しない", () => {
-      saveBestScore({ moves: 8, time: 20 });
-      const result = updateBestScore(10, 30);
+      saveConcentrationBestScore({ moves: 8, time: 20 });
+      const result = updateConcentrationBestScore(10, 30);
       expect(result).toBe(false);
-      expect(getBestScore()?.moves).toBe(8);
+      expect(getConcentrationBestScore()?.moves).toBe(8);
     });
   });
 });

--- a/src/lib/concentration-storage.ts
+++ b/src/lib/concentration-storage.ts
@@ -3,7 +3,7 @@ import type { ConcentrationBestScore } from "@/types/concentration";
 const STORAGE_KEY = "concentration-best-score";
 
 /** ベストスコアをlocalStorageから取得する */
-export function getBestScore(): ConcentrationBestScore | null {
+export function getConcentrationBestScore(): ConcentrationBestScore | null {
   if (typeof window === "undefined") return null;
   try {
     const data = localStorage.getItem(STORAGE_KEY);
@@ -15,7 +15,7 @@ export function getBestScore(): ConcentrationBestScore | null {
 }
 
 /** ベストスコアをlocalStorageに保存する */
-export function saveBestScore(score: ConcentrationBestScore): void {
+export function saveConcentrationBestScore(score: ConcentrationBestScore): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(score));
@@ -28,15 +28,15 @@ export function saveBestScore(score: ConcentrationBestScore): void {
  * 現在のスコアがベストスコアを更新するか判定し、更新する場合は保存する
  * ベストスコアの判定基準: 試行回数が少ない方が優先、同数なら時間が短い方
  */
-export function updateBestScore(moves: number, time: number): boolean {
-  const current = getBestScore();
+export function updateConcentrationBestScore(moves: number, time: number): boolean {
+  const current = getConcentrationBestScore();
 
   if (
     !current ||
     moves < current.moves ||
     (moves === current.moves && time < current.time)
   ) {
-    saveBestScore({ moves, time });
+    saveConcentrationBestScore({ moves, time });
     return true;
   }
 


### PR DESCRIPTION
## Summary

- `getBestScore` → `getConcentrationBestScore` 等、concentration の Storage 関数3つにゲーム名プレフィックスを追加
- 他ゲーム（high-and-low, blackjack, poker）と命名規則を統一
- `/refactor-game` による全ゲーム規約チェックで検出した違反を修正
- poker のコンポーネントテスト欠落は #49 に切り出し済み

Closes #41

## Test plan

- [x] `npm run lint` パス
- [x] `npm run test:run` 229件パス
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)