### PR TITLE
feat: PreToolUse hook で破壊的コマンドをブロック

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# PreToolUse hook: 破壊的なシェルコマンドの実行をブロックする
+# Bash ツールの実行前にコマンドを検査し、危険なパターンを検出した場合は exit 2 でブロックする
+
+COMMAND=$(jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# rm -rf（オプション付きも含む）
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\b'; then
+  echo "ブロック: rm -rf は実行できません。ファイル削除は手動で行ってください" >&2
+  exit 2
+fi
+
+# git push --force / -f
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push\s+.*(-f|--force)\b'; then
+  echo "ブロック: git push --force は実行できません。通常の git push を使用してください" >&2
+  exit 2
+fi
+
+# git reset --hard
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+reset\s+.*--hard\b'; then
+  echo "ブロック: git reset --hard は実行できません。変更を保持するリセット方法を使用してください" >&2
+  exit 2
+fi
+
+# npm publish
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)npm\s+publish\b'; then
+  echo "ブロック: npm publish は実行できません。パッケージ公開は手動で行ってください" >&2
+  exit 2
+fi
+
+# git checkout . （ワーキングツリー全体の変更破棄）
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+checkout\s+\.\s*$'; then
+  echo "ブロック: git checkout . は実行できません。変更の破棄は手動で行ってください" >&2
+  exit 2
+fi
+
+# git restore . （ワーキングツリー全体の変更破棄）
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+restore\s+\.\s*$'; then
+  echo "ブロック: git restore . は実行できません。変更の破棄は手動で行ってください" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": ".claude/hooks/protect-files.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-dangerous-commands.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- 破壊的シェルコマンドの実行を防止する PreToolUse hook を追加
- ブロック対象: 強制削除、強制プッシュ、ハードリセット、パッケージ公開、ワーキングツリー全破棄
- `.claude/settings.json` に Bash マッチャーで hook を登録

## Test plan
- [ ] ブロック対象コマンドが exit 2 でブロックされることを確認
- [ ] 通常コマンド（`npm run lint`, `git push` 等）が正常に通過することを確認

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)