### PR TITLE
fix: block-dangerous-commands hook のコミットメッセージ誤反応を修正

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -9,42 +9,43 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# 引用符内の文字列を除去し、実際に実行されるコマンド部分のみを検査対象にする
-# （例: git commit -m "rm -rf を削除" → git commit -m "" ）
-SANITIZED=$(echo "$COMMAND" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")
+# git commit のメッセージ引数のみを除去し、実際に実行されるコマンド部分は検査対象に残す
+# （例: git commit -m "rm -rf を削除" → git commit -m ）
+# sh -c "rm -rf /" 等の実行系コマンドの引用符内は除去しない
+SANITIZED=$(echo "$COMMAND" | sed -E "s/(git[[:space:]]+commit[[:space:]]+.*(--message|-m)[[:space:]]+)\"[^\"]*\"/\1/g; s/(git[[:space:]]+commit[[:space:]]+.*(--message|-m)[[:space:]]+)'[^']*'/\1/g")
 
-# rm -rf（オプション付きも含む）
-if echo "$SANITIZED" | grep -qE '(^|[;&|]\s*)rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\b'; then
+# rm -rf（オプション付きも含む、引用符内も検出）
+if echo "$SANITIZED" | grep -qE '(^|[;&|"'"'"'\s])rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\b'; then
   echo "ブロック: rm -rf は実行できません。ファイル削除は手動で行ってください" >&2
   exit 2
 fi
 
 # git push --force / -f
-if echo "$SANITIZED" | grep -qE '(^|[;&|]\s*)git\s+push\s+.*(-f|--force)\b'; then
+if echo "$SANITIZED" | grep -qE '(^|[;&|"'"'"'\s])git\s+push\s+.*(-f|--force)\b'; then
   echo "ブロック: git push --force は実行できません。通常の git push を使用してください" >&2
   exit 2
 fi
 
 # git reset --hard
-if echo "$SANITIZED" | grep -qE '(^|[;&|]\s*)git\s+reset\s+.*--hard\b'; then
+if echo "$SANITIZED" | grep -qE '(^|[;&|"'"'"'\s])git\s+reset\s+.*--hard\b'; then
   echo "ブロック: git reset --hard は実行できません。変更を保持するリセット方法を使用してください" >&2
   exit 2
 fi
 
 # npm publish
-if echo "$SANITIZED" | grep -qE '(^|[;&|]\s*)npm\s+publish\b'; then
+if echo "$SANITIZED" | grep -qE '(^|[;&|"'"'"'\s])npm\s+publish\b'; then
   echo "ブロック: npm publish は実行できません。パッケージ公開は手動で行ってください" >&2
   exit 2
 fi
 
 # git checkout . （ワーキングツリー全体の変更破棄）
-if echo "$SANITIZED" | grep -qE '(^|[;&|]\s*)git\s+checkout\s+\.\s*$'; then
+if echo "$SANITIZED" | grep -qE '(^|[;&|"'"'"'\s])git\s+checkout\s+\.\s*["'"'"']?\s*$'; then
   echo "ブロック: git checkout . は実行できません。変更の破棄は手動で行ってください" >&2
   exit 2
 fi
 
 # git restore . （ワーキングツリー全体の変更破棄）
-if echo "$SANITIZED" | grep -qE '(^|[;&|]\s*)git\s+restore\s+\.\s*$'; then
+if echo "$SANITIZED" | grep -qE '(^|[;&|"'"'"'\s])git\s+restore\s+\.\s*["'"'"']?\s*$'; then
   echo "ブロック: git restore . は実行できません。変更の破棄は手動で行ってください" >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary
- 引用符内の文字列を除去してからパターンマッチするよう修正
- `git commit -m "rm -rf を削除"` のようなコミットメッセージがブロックされなくなる
- 実際の危険コマンド（`rm -rf`, `npm publish` 等）は引き続きブロックされる

Closes #63

## Test plan
- [ ] `git commit -m "rm -rf を削除"` がブロックされないことを確認
- [ ] `git commit -m "npm publish を防止"` がブロックされないことを確認
- [ ] 実際の `rm -rf /tmp/test` がブロックされることを確認
- [ ] 実際の `npm publish` がブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)