### PR TITLE
feat: SessionStart hook でコンテキスト圧縮後にリマインダーを表示

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'リマインダー: useSyncExternalStore の getSnapshot はキャッシュ済み参照を返すこと。JSON.parse 直接呼び出しは無限ループの原因。詳細は .claude/rules/pitfalls.md を参照。'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- コンテキスト圧縮（compact）後に `pitfalls.md` の重要な注意点が失われないよう、`SessionStart` hook を追加
- `useSyncExternalStore` のキャッシュ問題等のリマインダーを自動表示

Closes #44

## Test plan

- [ ] 長いセッションでコンテキスト圧縮を発生させ、リマインダーが表示されることを確認
- [ ] 通常のセッション開始時にはリマインダーが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)