### PR TITLE
feat: poker コンポーネントテストを追加

### DIFF
--- a/src/components/poker/__tests__/poker-card.test.tsx
+++ b/src/components/poker/__tests__/poker-card.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PokerCard } from "../poker-card";
+import type { PlayingCard } from "@/types/poker";
+
+describe("PokerCard", () => {
+  const spadeAce: PlayingCard = {
+    id: 0,
+    suit: "spade",
+    rank: "A",
+    value: 14,
+  };
+  const heartTen: PlayingCard = {
+    id: 1,
+    suit: "heart",
+    rank: "10",
+    value: 10,
+  };
+
+  it("裏向きのカードを表示する", () => {
+    render(<PokerCard card={null} faceDown />);
+    expect(screen.getByRole("img")).toHaveAccessibleName("裏向きのカード");
+  });
+
+  it("表向きのカードにスートとランクのaria-labelを持つ", () => {
+    render(<PokerCard card={spadeAce} />);
+    expect(screen.getByRole("img")).toHaveAccessibleName("♠A");
+  });
+
+  it("ホールド中のカードのaria-labelに「(ホールド中)」が付く", () => {
+    render(<PokerCard card={spadeAce} held />);
+    expect(screen.getByRole("img")).toHaveAccessibleName("♠A (ホールド中)");
+  });
+
+  it("ランクテキストとスートシンボルを表示する", () => {
+    render(<PokerCard card={heartTen} />);
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("♥")).toBeInTheDocument();
+  });
+
+  it("held=trueの時HOLDラベルがopacity-100になる", () => {
+    render(<PokerCard card={spadeAce} held />);
+    const holdLabel = screen.getByText("HOLD");
+    expect(holdLabel).toHaveClass("opacity-100");
+  });
+
+  it("held=falseの時HOLDラベルがopacity-0になる", () => {
+    render(<PokerCard card={spadeAce} />);
+    const holdLabel = screen.getByText("HOLD");
+    expect(holdLabel).toHaveClass("opacity-0");
+  });
+
+  it("held=trueの時-translate-y-2が適用される", () => {
+    render(<PokerCard card={spadeAce} held />);
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("-translate-y-2");
+  });
+
+  it("clickable=trueの時onClickが発火する", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<PokerCard card={spadeAce} clickable onClick={onClick} />);
+    await user.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("clickable=falseの時onClickが発火しない", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<PokerCard card={spadeAce} onClick={onClick} />);
+    await user.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("cardがnullでfaceDown=falseの場合は何も描画しない", () => {
+    const { container } = render(<PokerCard card={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/poker/__tests__/poker-header.test.tsx
+++ b/src/components/poker/__tests__/poker-header.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PokerHeader } from "../poker-header";
+import { MAX_ROUNDS } from "@/lib/poker-cards";
+
+describe("PokerHeader", () => {
+  const defaultProps = {
+    round: 0,
+    totalScore: 0,
+    phase: "idle" as const,
+    bestScore: null,
+    onStart: vi.fn(),
+    onReset: vi.fn(),
+  };
+
+  it("idle状態かつround=0で「ゲーム開始」ボタンを表示する", () => {
+    render(<PokerHeader {...defaultProps} />);
+    expect(screen.getByText("ゲーム開始")).toBeInTheDocument();
+  });
+
+  it("dealing状態で「やり直す」ボタンを表示する", () => {
+    render(<PokerHeader {...defaultProps} phase="dealing" round={1} />);
+    expect(screen.getByText("やり直す")).toBeInTheDocument();
+  });
+
+  it("holding状態で「やり直す」ボタンを表示する", () => {
+    render(<PokerHeader {...defaultProps} phase="holding" round={1} />);
+    expect(screen.getByText("やり直す")).toBeInTheDocument();
+  });
+
+  it("drawing状態で「やり直す」ボタンを表示する", () => {
+    render(<PokerHeader {...defaultProps} phase="drawing" round={1} />);
+    expect(screen.getByText("やり直す")).toBeInTheDocument();
+  });
+
+  it("result状態で「やり直す」ボタンを表示する", () => {
+    render(<PokerHeader {...defaultProps} phase="result" round={1} />);
+    expect(screen.getByText("やり直す")).toBeInTheDocument();
+  });
+
+  it("gameOver状態かつround>=MAX_ROUNDSで「もう一度遊ぶ」ボタンを表示する", () => {
+    render(
+      <PokerHeader
+        {...defaultProps}
+        phase="gameOver"
+        round={MAX_ROUNDS}
+      />
+    );
+    expect(screen.getByText("もう一度遊ぶ")).toBeInTheDocument();
+  });
+
+  it("スコアバッジを表示する", () => {
+    render(
+      <PokerHeader
+        {...defaultProps}
+        phase="holding"
+        round={3}
+        totalScore={150}
+      />
+    );
+    expect(screen.getByText(/ラウンド: 3/)).toBeInTheDocument();
+    expect(screen.getByText(/スコア: 150pt/)).toBeInTheDocument();
+  });
+
+  it("ベストスコアを表示する", () => {
+    render(
+      <PokerHeader
+        {...defaultProps}
+        bestScore={{ maxScore: 500 }}
+      />
+    );
+    expect(screen.getByText(/ベスト: 500pt/)).toBeInTheDocument();
+  });
+
+  it("bestScore=nullの時ベストスコアを表示しない", () => {
+    render(<PokerHeader {...defaultProps} />);
+    expect(screen.queryByText(/ベスト:/)).not.toBeInTheDocument();
+  });
+
+  it("ゲーム開始ボタンクリックでonStartが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    render(<PokerHeader {...defaultProps} onStart={onStart} />);
+    await user.click(screen.getByText("ゲーム開始"));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("やり直すボタンクリックでonResetが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onReset = vi.fn();
+    render(
+      <PokerHeader {...defaultProps} phase="holding" round={1} onReset={onReset} />
+    );
+    await user.click(screen.getByText("やり直す"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("もう一度遊ぶボタンクリックでonStartが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    render(
+      <PokerHeader
+        {...defaultProps}
+        phase="gameOver"
+        round={MAX_ROUNDS}
+        onStart={onStart}
+      />
+    );
+    await user.click(screen.getByText("もう一度遊ぶ"));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `poker-card.test.tsx`: 裏向き/表向き/ホールド状態の aria-label、HOLD ラベル表示、translate-y-2 transform、clickable による onClick 制御など 10 テスト
- `poker-header.test.tsx`: Phase ごとのボタン表示、スコアバッジ、ベストスコア表示、コールバック発火など 12 テスト
- 他ゲーム（blackjack, high-and-low）の card/header テストパターンに準拠

Closes #49

## Test plan
- [x] `npx vitest run src/components/poker/__tests__/poker-card.test.tsx` — 10 tests pass
- [x] `npx vitest run src/components/poker/__tests__/poker-header.test.tsx` — 12 tests pass
- [x] `npm run lint` — no errors
- [x] `npm run test:run` — all 369 tests pass
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)