### PR TITLE
/game-debug スキルに golf, pyramid, spider の対応を追加

### DIFF
--- a/.claude/skills/game-debug/SKILL.md
+++ b/.claude/skills/game-debug/SKILL.md
@@ -33,6 +33,9 @@ argument-hint: "[ゲーム名(英語kebab-case)]"
 | high-and-low | `highAndLowReducer` | `initialHighAndLowState` | `createDeck()` |
 | blackjack | `blackjackReducer` | `initialBlackjackState` | `createDeck()` |
 | poker | `pokerReducer` | `initialPokerState` | `createDeck()` |
+| golf | `golfReducer` | `initialGolfState` | `createDeck()` |
+| pyramid | `pyramidReducer` | `initialPyramidState` | `createDeck()` |
+| spider | `spiderReducer` | `initialSpiderState` | `createDeck()` |
 
 指定されたゲームが上記に含まれない場合は、エラーを表示して終了する。
 


### PR DESCRIPTION
## Summary

- `/game-debug` スキルの対応ゲームテーブルに golf, pyramid, spider の 3 ゲームを追加
- 各ゲームの reducer / initialState / デッキ生成関数の export 名を実装ファイルから確認して記載

Closes #99

## Test plan

- [ ] `/game-debug golf` でゴルフソリティアのデバッグが開始できること
- [ ] `/game-debug pyramid` でピラミッドのデバッグが開始できること
- [ ] `/game-debug spider` でスパイダーソリティアのデバッグが開始できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)