### PR TITLE
feat: テンプレイ（Ten Play）ゲームを追加

### DIFF
--- a/src/app/ten-play/page.tsx
+++ b/src/app/ten-play/page.tsx
@@ -1,0 +1,5 @@
+import { TenPlayBoard } from "@/components/ten-play/ten-play-board";
+
+export default function TenPlayPage() {
+  return <TenPlayBoard />;
+}

--- a/src/components/home/game-list.tsx
+++ b/src/components/home/game-list.tsx
@@ -10,6 +10,7 @@ import type { PokerBestScore } from "@/types/poker";
 import type { PyramidBestScore } from "@/types/pyramid";
 import type { GolfBestScore } from "@/types/golf";
 import type { SpiderBestScore } from "@/types/spider";
+import type { TenPlayBestScore } from "@/types/ten-play";
 
 /** ゲーム定義 */
 const games = [
@@ -61,6 +62,13 @@ const games = [
     description: "K〜Aの列を8組完成させよう",
     emoji: "🕷️",
     storageKey: "spider-best-score",
+  },
+  {
+    id: "ten-play",
+    title: "テンプレイ",
+    description: "合計10のペアを見つけて除去しよう",
+    emoji: "🔟",
+    storageKey: "ten-play-best-score",
   },
 ] as const;
 
@@ -145,6 +153,21 @@ function formatSpiderBest(data: string): string | null {
   }
 }
 
+/** テンプレイのベストスコアをフォーマット */
+function formatTenPlayBest(data: string): string | null {
+  try {
+    const best = JSON.parse(data) as TenPlayBestScore;
+    if (typeof best.bestTime !== "number" || !Number.isFinite(best.bestTime)) {
+      return null;
+    }
+    const m = Math.floor(best.bestTime / 60);
+    const s = best.bestTime % 60;
+    return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  } catch {
+    return null;
+  }
+}
+
 /** ゲームIDに応じたベストスコア表示文字列を返す */
 function formatBestScore(gameId: string, data: string): string | null {
   switch (gameId) {
@@ -162,6 +185,8 @@ function formatBestScore(gameId: string, data: string): string | null {
       return formatGolfBest(data);
     case "spider":
       return formatSpiderBest(data);
+    case "ten-play":
+      return formatTenPlayBest(data);
     default:
       return null;
   }

--- a/src/components/ten-play/ten-play-board.tsx
+++ b/src/components/ten-play/ten-play-board.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTenPlay } from "@/hooks/useTenPlay";
+import { getTotalRemainingCards } from "@/lib/ten-play-cards";
+import { TenPlayHeader } from "./ten-play-header";
+import { TenPlayTableau } from "./ten-play-tableau";
+import { TenPlayGameOverDialog } from "./ten-play-game-over-dialog";
+import { cn } from "@/lib/utils";
+
+/** テンプレイのメインゲームボード */
+export function TenPlayBoard() {
+  const {
+    state,
+    bestScore,
+    startGame,
+    selectCard,
+    dismissDialog,
+    resetGame,
+  } = useTenPlay();
+
+  const showBoard = state.phase !== "idle";
+  const isWin = state.result === "win";
+  const remainingCards = getTotalRemainingCards(state.tableau, state.stock);
+
+  return (
+    <div
+      className={cn(
+        "game-background flex flex-col items-center px-4 py-6 sm:py-10",
+        state.phase === "cleared" && isWin && "celebrate"
+      )}
+    >
+      <div className="w-full max-w-2xl">
+        <TenPlayHeader
+          elapsedTime={state.elapsedTime}
+          removedCount={state.removedCount}
+          remainingCards={remainingCards}
+          stockCount={state.stock.length}
+          phase={state.phase}
+          bestScore={bestScore}
+          onStart={startGame}
+          onReset={resetGame}
+        />
+
+        {showBoard && (
+          <div className="flex flex-col items-center gap-6">
+            <TenPlayTableau
+              tableau={state.tableau}
+              selectedIndices={state.selectedIndices}
+              invalidPair={state.invalidPair}
+              onSelectCard={selectCard}
+            />
+          </div>
+        )}
+      </div>
+
+      <TenPlayGameOverDialog
+        open={state.dialogOpen}
+        result={state.result}
+        remainingCards={remainingCards}
+        removedCount={state.removedCount}
+        elapsedTime={state.elapsedTime}
+        isNewBest={state.isNewBest}
+        onPlayAgain={() => {
+          startGame();
+        }}
+        onClose={dismissDialog}
+      />
+    </div>
+  );
+}

--- a/src/components/ten-play/ten-play-card.tsx
+++ b/src/components/ten-play/ten-play-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { SUIT_SYMBOLS, SUIT_COLORS } from "@/lib/ten-play-cards";
+import type { PlayingCard } from "@/types/ten-play";
+
+type TenPlayCardProps = {
+  card: PlayingCard;
+  /** 選択中 */
+  selected?: boolean;
+  /** 不正ペア表示 */
+  invalid?: boolean;
+  /** クリック時のコールバック */
+  onClick?: () => void;
+};
+
+/** テンプレイのトランプカード表示コンポーネント */
+export function TenPlayCard({
+  card,
+  selected = false,
+  invalid = false,
+  onClick,
+}: TenPlayCardProps) {
+  const suitColor = SUIT_COLORS[card.suit];
+  const suitSymbol = SUIT_SYMBOLS[card.suit];
+  const textColor = suitColor === "red" ? "text-red-600" : "text-gray-800";
+
+  const cardContent = (
+    <div className="flex flex-col items-center justify-center gap-0">
+      <span
+        className={cn(
+          "text-xl sm:text-2xl font-bold select-none leading-tight",
+          textColor
+        )}
+      >
+        {card.rank}
+      </span>
+      <span
+        className={cn(
+          "text-base sm:text-lg select-none leading-tight",
+          textColor
+        )}
+      >
+        {suitSymbol}
+      </span>
+    </div>
+  );
+
+  return (
+    <div className="card-container w-14 h-20 sm:w-16 sm:h-22">
+      <div className="card-inner w-full h-full flipped">
+        {/* 裏面（常にflippedのため非表示） */}
+        <div
+          className={cn(
+            "card-face shadow-md",
+            "bg-gradient-to-br from-amber-400 via-orange-400 to-red-400"
+          )}
+        >
+          <span className="text-lg text-white/90 select-none">?</span>
+        </div>
+
+        {/* 表面 */}
+        <button
+          type="button"
+          className={cn(
+            "card-face card-back shadow-lg transition-all duration-200",
+            "bg-white border border-gray-200",
+            "cursor-pointer hover:shadow-xl hover:-translate-y-0.5",
+            selected && "ring-2 ring-blue-500 ring-offset-1",
+            invalid && "ring-2 ring-red-500 ring-offset-1 animate-shake"
+          )}
+          onClick={onClick}
+          aria-label={`${SUIT_SYMBOLS[card.suit]}${card.rank}`}
+        >
+          {cardContent}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** 空スロットの表示コンポーネント */
+export function TenPlayEmptySlot() {
+  return (
+    <div className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200" />
+  );
+}

--- a/src/components/ten-play/ten-play-game-over-dialog.tsx
+++ b/src/components/ten-play/ten-play-game-over-dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { TenPlayGameResult } from "@/types/ten-play";
+
+type TenPlayGameOverDialogProps = {
+  open: boolean;
+  result: TenPlayGameResult | null;
+  remainingCards: number;
+  removedCount: number;
+  elapsedTime: number;
+  isNewBest: boolean;
+  onPlayAgain: () => void;
+  onClose: () => void;
+};
+
+/** 秒数をMM:SS形式にフォーマット */
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+/** ゲーム終了ダイアログ */
+export function TenPlayGameOverDialog({
+  open,
+  result,
+  remainingCards,
+  removedCount,
+  elapsedTime,
+  isNewBest,
+  onPlayAgain,
+  onClose,
+}: TenPlayGameOverDialogProps) {
+  const isWin = result === "win";
+
+  const title = (() => {
+    if (isWin) {
+      return isNewBest ? "🎉 新記録でクリア！" : "🎊 クリア！";
+    }
+    return "😢 手詰まり...";
+  })();
+
+  const description = (() => {
+    if (isWin) return "すべてのカードを除去しました！";
+    return "これ以上除去できるペアがありません...";
+  })();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose();
+      }}
+    >
+      <DialogContent
+        className="sm:max-w-md rounded-2xl"
+        aria-describedby="ten-play-game-over-description"
+      >
+        <DialogHeader>
+          <DialogTitle className="text-center text-2xl">{title}</DialogTitle>
+          <DialogDescription
+            id="ten-play-game-over-description"
+            className="text-center text-base pt-2"
+          >
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4 py-4">
+          <div className="flex gap-6 text-center">
+            <div>
+              <p className="text-3xl font-bold text-gray-800">{remainingCards}</p>
+              <p className="text-sm text-gray-500">残りカード</p>
+            </div>
+            <div>
+              <p className="text-3xl font-bold text-gray-800">{removedCount}</p>
+              <p className="text-sm text-gray-500">除去回数</p>
+            </div>
+            <div>
+              <p className="text-3xl font-bold text-gray-800">
+                {formatTime(elapsedTime)}
+              </p>
+              <p className="text-sm text-gray-500">タイム</p>
+            </div>
+          </div>
+          {isNewBest && (
+            <p className="text-sm font-medium text-emerald-600">
+              ベストスコアを更新しました！
+            </p>
+          )}
+          <div className="flex gap-3 mt-2">
+            <Button
+              onClick={onPlayAgain}
+              size="lg"
+              className="rounded-xl px-6"
+            >
+              もう一度遊ぶ
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ten-play/ten-play-header.tsx
+++ b/src/components/ten-play/ten-play-header.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import type { TenPlayPhase, TenPlayBestScore } from "@/types/ten-play";
+
+type TenPlayHeaderProps = {
+  elapsedTime: number;
+  removedCount: number;
+  remainingCards: number;
+  stockCount: number;
+  phase: TenPlayPhase;
+  bestScore: TenPlayBestScore | null;
+  onStart: () => void;
+  onReset: () => void;
+};
+
+/** 秒数をMM:SS形式にフォーマット */
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+/** テンプレイのゲームヘッダー */
+export function TenPlayHeader({
+  elapsedTime,
+  removedCount,
+  remainingCards,
+  stockCount,
+  phase,
+  bestScore,
+  onStart,
+  onReset,
+}: TenPlayHeaderProps) {
+  const isActive = phase === "playing";
+  const isGameOver = phase === "cleared" || phase === "stuck";
+
+  return (
+    <div className="glass rounded-2xl p-4 sm:p-6 shadow-lg mb-4 sm:mb-6">
+      {/* タイトル */}
+      <div className="relative text-center mb-4">
+        <Link
+          href="/"
+          className="absolute left-0 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="ホームに戻る"
+        >
+          <ArrowLeft className="size-5" />
+        </Link>
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-800">
+          テンプレイ
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          合計10のペアを見つけて除去しよう
+        </p>
+      </div>
+
+      {/* ステータス表示 */}
+      {phase !== "idle" && (
+        <div className="flex justify-center gap-3 sm:gap-4 mb-4 flex-wrap">
+          <Badge
+            variant="secondary"
+            className="text-sm px-3 py-1.5 rounded-xl"
+          >
+            ⏱ {formatTime(elapsedTime)}
+          </Badge>
+          <Badge
+            variant="secondary"
+            className="text-sm px-3 py-1.5 rounded-xl"
+          >
+            🃏 残り: {remainingCards}枚
+          </Badge>
+          <Badge
+            variant="secondary"
+            className="text-sm px-3 py-1.5 rounded-xl"
+          >
+            📦 山札: {stockCount}枚
+          </Badge>
+          <Badge
+            variant="secondary"
+            className="text-sm px-3 py-1.5 rounded-xl"
+          >
+            ✨ 除去: {removedCount}回
+          </Badge>
+        </div>
+      )}
+
+      {/* ベストスコア */}
+      {bestScore && (
+        <div className="text-center mb-4">
+          <p className="text-xs text-gray-400">
+            🏆 ベスト: {formatTime(bestScore.bestTime)}
+          </p>
+        </div>
+      )}
+
+      {/* 操作ボタン */}
+      <div className="flex justify-center gap-3">
+        {phase === "idle" && (
+          <Button onClick={onStart} size="lg" className="rounded-xl px-8">
+            ゲーム開始
+          </Button>
+        )}
+        {isActive && (
+          <Button onClick={onReset} variant="outline" className="rounded-xl">
+            やり直す
+          </Button>
+        )}
+        {isGameOver && (
+          <Button onClick={onStart} size="lg" className="rounded-xl px-8">
+            もう一度遊ぶ
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ten-play/ten-play-tableau.tsx
+++ b/src/components/ten-play/ten-play-tableau.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { TenPlayCard, TenPlayEmptySlot } from "./ten-play-card";
+import type { PlayingCard } from "@/types/ten-play";
+
+type TenPlayTableauProps = {
+  tableau: (PlayingCard | null)[];
+  selectedIndices: number[];
+  invalidPair: number[] | null;
+  onSelectCard: (index: number) => void;
+};
+
+/** 13スロットのタブロー配置（7+6の2段構成） */
+export function TenPlayTableau({
+  tableau,
+  selectedIndices,
+  invalidPair,
+  onSelectCard,
+}: TenPlayTableauProps) {
+  // 上段: 0〜6（7枚）、下段: 7〜12（6枚）
+  const topRow = tableau.slice(0, 7);
+  const bottomRow = tableau.slice(7, 13);
+
+  return (
+    <div className="flex flex-col items-center gap-2 sm:gap-3">
+      {/* 上段: 7枚 */}
+      <div className="flex justify-center gap-1.5 sm:gap-2">
+        {topRow.map((card, i) => (
+          <div key={i}>
+            {card ? (
+              <TenPlayCard
+                card={card}
+                selected={selectedIndices.includes(i)}
+                invalid={invalidPair?.includes(i) ?? false}
+                onClick={() => onSelectCard(i)}
+              />
+            ) : (
+              <TenPlayEmptySlot />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* 下段: 6枚（センタリング） */}
+      <div className="flex justify-center gap-1.5 sm:gap-2">
+        {bottomRow.map((card, j) => {
+          const index = j + 7;
+          return (
+            <div key={index}>
+              {card ? (
+                <TenPlayCard
+                  card={card}
+                  selected={selectedIndices.includes(index)}
+                  invalid={invalidPair?.includes(index) ?? false}
+                  onClick={() => onSelectCard(index)}
+                />
+              ) : (
+                <TenPlayEmptySlot />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useTenPlay.ts
+++ b/src/hooks/useTenPlay.ts
@@ -1,0 +1,148 @@
+"use client";
+
+import {
+  useReducer,
+  useEffect,
+  useCallback,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+import {
+  tenPlayReducer,
+  initialTenPlayState,
+} from "@/lib/ten-play-reducer";
+import { createDeck } from "@/lib/ten-play-cards";
+import {
+  getTenPlayBestScore,
+  updateTenPlayBestScore,
+} from "@/lib/ten-play-storage";
+import type {
+  TenPlayBestScore,
+  TenPlayPhase,
+} from "@/types/ten-play";
+
+/** localStorageのベストスコアを購読するストア（キャッシュ付き） */
+let bestScoreListeners: Array<() => void> = [];
+let cachedBestScore: TenPlayBestScore | null = null;
+let cacheInitialized = false;
+
+function subscribeBestScore(callback: () => void) {
+  bestScoreListeners.push(callback);
+  // コンポーネント再マウント時にキャッシュを最新化
+  cachedBestScore = getTenPlayBestScore();
+  return () => {
+    bestScoreListeners = bestScoreListeners.filter((l) => l !== callback);
+  };
+}
+
+/** キャッシュ済みのスナップショットを返す（参照安定） */
+function getSnapshotBestScore(): TenPlayBestScore | null {
+  if (!cacheInitialized) {
+    cachedBestScore = getTenPlayBestScore();
+    cacheInitialized = true;
+  }
+  return cachedBestScore;
+}
+
+function getServerSnapshotBestScore(): TenPlayBestScore | null {
+  return null;
+}
+
+/** キャッシュを更新してリスナーに通知する */
+function notifyBestScoreChange() {
+  cachedBestScore = getTenPlayBestScore();
+  bestScoreListeners.forEach((l) => l());
+}
+
+/** テンプレイのゲームロジックを管理するカスタムフック */
+export function useTenPlay() {
+  const [state, dispatch] = useReducer(
+    tenPlayReducer,
+    initialTenPlayState
+  );
+  const prevPhaseRef = useRef<TenPlayPhase>("idle");
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const bestScore = useSyncExternalStore(
+    subscribeBestScore,
+    getSnapshotBestScore,
+    getServerSnapshotBestScore
+  );
+
+  // クリア時のみベストスコア更新（手詰まりは対象外）
+  useEffect(() => {
+    const isCleared = state.phase === "cleared";
+    const wasNotCleared = prevPhaseRef.current !== "cleared";
+    if (isCleared && wasNotCleared) {
+      const updated = updateTenPlayBestScore(state.elapsedTime);
+      dispatch({ type: "SET_NEW_BEST", isNewBest: updated });
+      if (updated) {
+        notifyBestScoreChange();
+      }
+    }
+    prevPhaseRef.current = state.phase;
+  }, [state.phase, state.elapsedTime]);
+
+  // タイマー管理
+  useEffect(() => {
+    if (state.phase === "playing") {
+      timerRef.current = setInterval(() => {
+        dispatch({ type: "TICK" });
+      }, 1000);
+    } else {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [state.phase]);
+
+  // 不正ペアの自動クリア（500ms後）
+  useEffect(() => {
+    if (state.invalidPair) {
+      const timer = setTimeout(() => {
+        dispatch({ type: "CLEAR_INVALID" });
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [state.invalidPair]);
+
+  /** ゲームを開始する */
+  const startGame = useCallback(() => {
+    dispatch({ type: "START_GAME", deck: createDeck() });
+  }, []);
+
+  /** カードを選択する */
+  const selectCard = useCallback(
+    (index: number) => {
+      if (state.phase !== "playing") return;
+      dispatch({ type: "SELECT_CARD", index });
+    },
+    [state.phase]
+  );
+
+  /** ダイアログを閉じる */
+  const dismissDialog = useCallback(() => {
+    dispatch({ type: "DISMISS_DIALOG" });
+  }, []);
+
+  /** ゲームをリセットする */
+  const resetGame = useCallback(() => {
+    dispatch({ type: "RESTART" });
+  }, []);
+
+  return {
+    state,
+    bestScore,
+    startGame,
+    selectCard,
+    dismissDialog,
+    resetGame,
+  };
+}

--- a/src/lib/__tests__/ten-play-cards.test.ts
+++ b/src/lib/__tests__/ten-play-cards.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import {
+  shuffle,
+  createDeck,
+  buildTableau,
+  isValidPair,
+  isSoloRemovable,
+  getRemainingTableauCards,
+  getTotalRemainingCards,
+  isStuck,
+  refillTableau,
+  getCardLabel,
+  SUIT_SYMBOLS,
+  TABLEAU_SIZE,
+  TARGET_SUM,
+  SOLO_REMOVE_VALUE,
+} from "../ten-play-cards";
+import type { PlayingCard } from "@/types/ten-play";
+
+/** テスト用カード生成ヘルパー */
+function card(
+  rank: PlayingCard["rank"],
+  suit: PlayingCard["suit"] = "spade",
+  id: number = 0
+): PlayingCard {
+  const values: Record<string, number> = {
+    A: 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+    "10": 10,
+    J: 11,
+    Q: 12,
+    K: 13,
+  };
+  return { id, suit, rank, value: values[rank] };
+}
+
+describe("定数", () => {
+  it("TABLEAU_SIZEは13", () => {
+    expect(TABLEAU_SIZE).toBe(13);
+  });
+
+  it("TARGET_SUMは10", () => {
+    expect(TARGET_SUM).toBe(10);
+  });
+
+  it("SOLO_REMOVE_VALUEは10", () => {
+    expect(SOLO_REMOVE_VALUE).toBe(10);
+  });
+});
+
+describe("shuffle", () => {
+  it("元の配列を変更しない", () => {
+    const original = [1, 2, 3, 4, 5];
+    const copy = [...original];
+    shuffle(original);
+    expect(original).toEqual(copy);
+  });
+
+  it("すべての要素を保持する", () => {
+    const original = [1, 2, 3, 4, 5];
+    const shuffled = shuffle(original);
+    expect(shuffled.sort()).toEqual(original.sort());
+  });
+});
+
+describe("createDeck", () => {
+  it("52枚のカードを生成する", () => {
+    const deck = createDeck();
+    expect(deck).toHaveLength(52);
+  });
+
+  it("すべてのカードがユニークなIDを持つ", () => {
+    const deck = createDeck();
+    const ids = new Set(deck.map((c) => c.id));
+    expect(ids.size).toBe(52);
+  });
+
+  it("各スートに13枚ずつある", () => {
+    const deck = createDeck();
+    const suits = ["spade", "heart", "diamond", "club"] as const;
+    for (const suit of suits) {
+      expect(deck.filter((c) => c.suit === suit)).toHaveLength(13);
+    }
+  });
+
+  it("A=1, J=11, Q=12, K=13 の値を持つ", () => {
+    const deck = createDeck();
+    expect(deck.filter((c) => c.rank === "A").every((c) => c.value === 1)).toBe(true);
+    expect(deck.filter((c) => c.rank === "J").every((c) => c.value === 11)).toBe(true);
+    expect(deck.filter((c) => c.rank === "Q").every((c) => c.value === 12)).toBe(true);
+    expect(deck.filter((c) => c.rank === "K").every((c) => c.value === 13)).toBe(true);
+  });
+});
+
+describe("buildTableau", () => {
+  it("13スロットのタブローを生成する", () => {
+    const deck = createDeck();
+    const { tableau } = buildTableau(deck);
+    expect(tableau).toHaveLength(TABLEAU_SIZE);
+  });
+
+  it("山札は39枚", () => {
+    const deck = createDeck();
+    const { stock } = buildTableau(deck);
+    expect(stock).toHaveLength(39);
+  });
+
+  it("タブローにnullは含まれない（初期状態）", () => {
+    const deck = createDeck();
+    const { tableau } = buildTableau(deck);
+    expect(tableau.every((c) => c !== null)).toBe(true);
+  });
+});
+
+describe("isValidPair", () => {
+  it("合計10の数札ペアはtrue", () => {
+    expect(isValidPair(card("A"), card("9"))).toBe(true);
+    expect(isValidPair(card("2"), card("8"))).toBe(true);
+    expect(isValidPair(card("3"), card("7"))).toBe(true);
+    expect(isValidPair(card("4"), card("6"))).toBe(true);
+  });
+
+  it("合計10でない数札ペアはfalse", () => {
+    expect(isValidPair(card("A"), card("2"))).toBe(false);
+    expect(isValidPair(card("3"), card("8"))).toBe(false);
+    expect(isValidPair(card("5"), card("6"))).toBe(false);
+  });
+
+  it("同ランク絵札ペアはtrue", () => {
+    expect(isValidPair(card("J", "spade"), card("J", "heart"))).toBe(true);
+    expect(isValidPair(card("Q", "spade"), card("Q", "heart"))).toBe(true);
+    expect(isValidPair(card("K", "spade"), card("K", "heart"))).toBe(true);
+  });
+
+  it("異ランク絵札ペアはfalse", () => {
+    expect(isValidPair(card("J"), card("Q"))).toBe(false);
+    expect(isValidPair(card("J"), card("K"))).toBe(false);
+    expect(isValidPair(card("Q"), card("K"))).toBe(false);
+  });
+
+  it("数札と絵札の組み合わせはfalse", () => {
+    expect(isValidPair(card("A"), card("J"))).toBe(false);
+    expect(isValidPair(card("3"), card("K"))).toBe(false);
+  });
+
+  it("5+5=10はtrue", () => {
+    expect(isValidPair(card("5", "spade"), card("5", "heart"))).toBe(true);
+  });
+});
+
+describe("isSoloRemovable", () => {
+  it("10のカードはtrue", () => {
+    expect(isSoloRemovable(card("10"))).toBe(true);
+  });
+
+  it("10以外のカードはfalse", () => {
+    expect(isSoloRemovable(card("A"))).toBe(false);
+    expect(isSoloRemovable(card("9"))).toBe(false);
+    expect(isSoloRemovable(card("J"))).toBe(false);
+    expect(isSoloRemovable(card("K"))).toBe(false);
+  });
+});
+
+describe("getRemainingTableauCards", () => {
+  it("非nullカード数を返す", () => {
+    const tableau: (PlayingCard | null)[] = [card("A"), null, card("2"), null];
+    expect(getRemainingTableauCards(tableau)).toBe(2);
+  });
+
+  it("すべてnullなら0", () => {
+    expect(getRemainingTableauCards([null, null, null])).toBe(0);
+  });
+});
+
+describe("getTotalRemainingCards", () => {
+  it("タブローと山札の合計を返す", () => {
+    const tableau: (PlayingCard | null)[] = [card("A"), null, card("2")];
+    const stock = [card("3"), card("4")];
+    expect(getTotalRemainingCards(tableau, stock)).toBe(4);
+  });
+});
+
+describe("isStuck", () => {
+  it("10のカードがあれば手詰まりでない", () => {
+    const tableau: (PlayingCard | null)[] = [card("10"), card("K")];
+    expect(isStuck(tableau)).toBe(false);
+  });
+
+  it("有効な数札ペアがあれば手詰まりでない", () => {
+    const tableau: (PlayingCard | null)[] = [card("3"), card("7")];
+    expect(isStuck(tableau)).toBe(false);
+  });
+
+  it("同ランク絵札ペアがあれば手詰まりでない", () => {
+    const tableau: (PlayingCard | null)[] = [
+      card("J", "spade", 1),
+      card("J", "heart", 2),
+    ];
+    expect(isStuck(tableau)).toBe(false);
+  });
+
+  it("有効な手がなければ手詰まり", () => {
+    const tableau: (PlayingCard | null)[] = [
+      card("J", "spade", 1),
+      card("Q", "heart", 2),
+      card("K", "diamond", 3),
+    ];
+    expect(isStuck(tableau)).toBe(true);
+  });
+
+  it("nullスロットは無視する", () => {
+    const tableau: (PlayingCard | null)[] = [null, card("J", "spade", 1), null];
+    expect(isStuck(tableau)).toBe(true);
+  });
+
+  it("空のタブローは手詰まり（クリア判定済み前提）", () => {
+    expect(isStuck([null, null])).toBe(true);
+  });
+});
+
+describe("refillTableau", () => {
+  it("空きスロットに山札から補充する", () => {
+    const tableau: (PlayingCard | null)[] = [card("A", "spade", 1), null, null];
+    const stock = [card("2", "heart", 2), card("3", "heart", 3)];
+    const result = refillTableau(tableau, stock);
+    expect(result.tableau[0]?.id).toBe(1);
+    expect(result.tableau[1]?.id).toBe(2);
+    expect(result.tableau[2]?.id).toBe(3);
+    expect(result.stock).toHaveLength(0);
+  });
+
+  it("山札が足りなければ補充できる分だけ補充する", () => {
+    const tableau: (PlayingCard | null)[] = [null, null, null];
+    const stock = [card("A", "heart", 1)];
+    const result = refillTableau(tableau, stock);
+    expect(result.tableau[0]?.id).toBe(1);
+    expect(result.tableau[1]).toBeNull();
+    expect(result.tableau[2]).toBeNull();
+    expect(result.stock).toHaveLength(0);
+  });
+
+  it("空きがなければ何も変わらない", () => {
+    const tableau: (PlayingCard | null)[] = [card("A", "spade", 1)];
+    const stock = [card("2", "heart", 2)];
+    const result = refillTableau(tableau, stock);
+    expect(result.tableau[0]?.id).toBe(1);
+    expect(result.stock).toHaveLength(1);
+  });
+});
+
+describe("getCardLabel", () => {
+  it("スート記号+ランクのラベルを返す", () => {
+    expect(getCardLabel(card("A", "spade"))).toBe("♠A");
+    expect(getCardLabel(card("10", "heart"))).toBe("♥10");
+    expect(getCardLabel(card("K", "diamond"))).toBe("♦K");
+    expect(getCardLabel(card("3", "club"))).toBe("♣3");
+  });
+});
+
+describe("SUIT_SYMBOLS", () => {
+  it("各スートの記号が正しい", () => {
+    expect(SUIT_SYMBOLS.spade).toBe("♠");
+    expect(SUIT_SYMBOLS.heart).toBe("♥");
+    expect(SUIT_SYMBOLS.diamond).toBe("♦");
+    expect(SUIT_SYMBOLS.club).toBe("♣");
+  });
+});

--- a/src/lib/__tests__/ten-play-reducer.test.ts
+++ b/src/lib/__tests__/ten-play-reducer.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from "vitest";
+import { tenPlayReducer, initialTenPlayState } from "../ten-play-reducer";
+import type { TenPlayState, PlayingCard } from "@/types/ten-play";
+
+/** テスト用カード生成ヘルパー */
+function card(
+  rank: PlayingCard["rank"],
+  suit: PlayingCard["suit"] = "spade",
+  id: number = 0
+): PlayingCard {
+  const values: Record<string, number> = {
+    A: 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+    "10": 10,
+    J: 11,
+    Q: 12,
+    K: 13,
+  };
+  return { id, suit, rank, value: values[rank] };
+}
+
+/** テスト用の固定デッキを生成する（52枚） */
+function createTestDeck(): PlayingCard[] {
+  const suits: PlayingCard["suit"][] = ["spade", "heart", "diamond", "club"];
+  const ranks: PlayingCard["rank"][] = [
+    "A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K",
+  ];
+  const cards: PlayingCard[] = [];
+  let id = 0;
+  for (const suit of suits) {
+    for (const rank of ranks) {
+      cards.push(card(rank, suit, id++));
+    }
+  }
+  return cards;
+}
+
+describe("initialTenPlayState", () => {
+  it("初期状態が正しい", () => {
+    expect(initialTenPlayState.phase).toBe("idle");
+    expect(initialTenPlayState.tableau).toEqual([]);
+    expect(initialTenPlayState.stock).toEqual([]);
+    expect(initialTenPlayState.selectedIndices).toEqual([]);
+    expect(initialTenPlayState.removedCount).toBe(0);
+    expect(initialTenPlayState.result).toBeNull();
+    expect(initialTenPlayState.elapsedTime).toBe(0);
+    expect(initialTenPlayState.invalidPair).toBeNull();
+    expect(initialTenPlayState.isNewBest).toBe(false);
+    expect(initialTenPlayState.dialogOpen).toBe(false);
+  });
+});
+
+describe("START_GAME", () => {
+  it("タブローに13枚配置する", () => {
+    const deck = createTestDeck();
+    const state = tenPlayReducer(initialTenPlayState, { type: "START_GAME", deck });
+    expect(state.tableau).toHaveLength(13);
+    expect(state.tableau.every((c) => c !== null)).toBe(true);
+  });
+
+  it("山札は39枚", () => {
+    const deck = createTestDeck();
+    const state = tenPlayReducer(initialTenPlayState, { type: "START_GAME", deck });
+    expect(state.stock).toHaveLength(39);
+  });
+
+  it("playingフェーズになる", () => {
+    const deck = createTestDeck();
+    const state = tenPlayReducer(initialTenPlayState, { type: "START_GAME", deck });
+    expect(state.phase).toBe("playing");
+  });
+});
+
+describe("SELECT_CARD", () => {
+  it("1枚目を選択する", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [card("A", "spade", 1), card("9", "heart", 2)],
+      stock: [],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    expect(newState.selectedIndices).toEqual([0]);
+  });
+
+  it("選択済みのカードを選択解除する", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [card("A", "spade", 1), card("9", "heart", 2)],
+      stock: [],
+      selectedIndices: [0],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    expect(newState.selectedIndices).toEqual([]);
+  });
+
+  it("10のカードは単独除去される", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [
+        card("10", "spade", 1),
+        card("A", "heart", 2),
+        card("9", "diamond", 3),
+      ],
+      stock: [card("5", "club", 4)],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    // 10が除去され、山札から補充
+    expect(newState.tableau[0]?.id).toBe(4);
+    expect(newState.removedCount).toBe(1);
+    expect(newState.selectedIndices).toEqual([]);
+  });
+
+  it("合計10の数札ペアを除去する", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [
+        card("A", "spade", 1),
+        card("9", "heart", 2),
+        card("K", "diamond", 3),
+      ],
+      stock: [card("5", "club", 4), card("6", "club", 5)],
+      selectedIndices: [0],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 1 });
+    // A+9=10 → ペア除去 → 補充
+    expect(newState.tableau[0]?.id).toBe(4);
+    expect(newState.tableau[1]?.id).toBe(5);
+    expect(newState.removedCount).toBe(1);
+  });
+
+  it("同ランク絵札ペアを除去する", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [
+        card("J", "spade", 1),
+        card("J", "heart", 2),
+        card("A", "diamond", 3),
+      ],
+      stock: [card("5", "club", 4), card("6", "club", 5)],
+      selectedIndices: [0],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 1 });
+    expect(newState.removedCount).toBe(1);
+    expect(newState.tableau[0]?.id).toBe(4);
+    expect(newState.tableau[1]?.id).toBe(5);
+  });
+
+  it("不正ペアでinvalidPairがセットされる", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [
+        card("A", "spade", 1),
+        card("2", "heart", 2),
+        card("3", "diamond", 3),
+      ],
+      stock: [],
+      selectedIndices: [0],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 1 });
+    expect(newState.invalidPair).toEqual([0, 1]);
+    expect(newState.selectedIndices).toEqual([]);
+  });
+
+  it("nullスロットは選択できない", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [null, card("A", "heart", 1)],
+      stock: [],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    expect(newState.selectedIndices).toEqual([]);
+  });
+
+  it("playingフェーズ以外では何もしない", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "idle",
+      tableau: [card("A", "spade", 1)],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    expect(newState).toEqual(state);
+  });
+
+  it("全カード除去でclearedフェーズに遷移する", () => {
+    // タブローに10が1枚だけ、山札なし
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [card("10", "spade", 1)],
+      stock: [],
+    };
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    expect(newState.phase).toBe("cleared");
+    expect(newState.result).toBe("win");
+    expect(newState.dialogOpen).toBe(true);
+  });
+
+  it("除去後に手詰まりならstuckフェーズに遷移する", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      tableau: [
+        card("10", "spade", 1),
+        card("J", "heart", 2),
+        card("Q", "diamond", 3),
+      ],
+      stock: [],
+    };
+    // 10を単独除去 → 残りJ,Q → 手詰まり
+    const newState = tenPlayReducer(state, { type: "SELECT_CARD", index: 0 });
+    expect(newState.phase).toBe("stuck");
+    expect(newState.result).toBe("lose");
+    expect(newState.dialogOpen).toBe(true);
+  });
+});
+
+describe("CLEAR_INVALID", () => {
+  it("invalidPairをクリアする", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      invalidPair: [0, 1],
+    };
+    const newState = tenPlayReducer(state, { type: "CLEAR_INVALID" });
+    expect(newState.invalidPair).toBeNull();
+  });
+});
+
+describe("TICK", () => {
+  it("playingフェーズで経過時間をインクリメントする", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      elapsedTime: 10,
+    };
+    const newState = tenPlayReducer(state, { type: "TICK" });
+    expect(newState.elapsedTime).toBe(11);
+  });
+
+  it("playing以外では何もしない", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "idle",
+      elapsedTime: 10,
+    };
+    const newState = tenPlayReducer(state, { type: "TICK" });
+    expect(newState.elapsedTime).toBe(10);
+  });
+});
+
+describe("SET_NEW_BEST", () => {
+  it("isNewBestを設定する", () => {
+    const state = tenPlayReducer(initialTenPlayState, {
+      type: "SET_NEW_BEST",
+      isNewBest: true,
+    });
+    expect(state.isNewBest).toBe(true);
+  });
+});
+
+describe("DISMISS_DIALOG", () => {
+  it("ダイアログを閉じる", () => {
+    const state: TenPlayState = { ...initialTenPlayState, dialogOpen: true };
+    const newState = tenPlayReducer(state, { type: "DISMISS_DIALOG" });
+    expect(newState.dialogOpen).toBe(false);
+  });
+});
+
+describe("RESTART", () => {
+  it("初期状態に戻る", () => {
+    const state: TenPlayState = {
+      ...initialTenPlayState,
+      phase: "playing",
+      removedCount: 10,
+      elapsedTime: 60,
+    };
+    const newState = tenPlayReducer(state, { type: "RESTART" });
+    expect(newState).toEqual(initialTenPlayState);
+  });
+});

--- a/src/lib/__tests__/ten-play-storage.test.ts
+++ b/src/lib/__tests__/ten-play-storage.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getTenPlayBestScore,
+  saveTenPlayBestScore,
+  updateTenPlayBestScore,
+} from "../ten-play-storage";
+
+/** localStorageのモック */
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.clearAllMocks();
+});
+
+describe("getTenPlayBestScore", () => {
+  it("データがない場合はnullを返す", () => {
+    expect(getTenPlayBestScore()).toBeNull();
+  });
+
+  it("保存済みデータを返す", () => {
+    localStorageMock.setItem(
+      "ten-play-best-score",
+      JSON.stringify({ bestTime: 120, date: "2026-03-20" })
+    );
+    expect(getTenPlayBestScore()).toEqual({ bestTime: 120, date: "2026-03-20" });
+  });
+
+  it("不正なJSONの場合はnullを返す", () => {
+    localStorageMock.setItem("ten-play-best-score", "invalid");
+    localStorageMock.getItem.mockReturnValueOnce("invalid");
+    expect(getTenPlayBestScore()).toBeNull();
+  });
+});
+
+describe("saveTenPlayBestScore", () => {
+  it("正しいキーでlocalStorageに保存する", () => {
+    saveTenPlayBestScore({ bestTime: 90, date: "2026-03-20" });
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "ten-play-best-score",
+      JSON.stringify({ bestTime: 90, date: "2026-03-20" })
+    );
+  });
+});
+
+describe("updateTenPlayBestScore", () => {
+  it("初回は常に更新する", () => {
+    const result = updateTenPlayBestScore(120);
+    expect(result).toBe(true);
+  });
+
+  it("既存より短い時間なら更新する", () => {
+    localStorageMock.setItem(
+      "ten-play-best-score",
+      JSON.stringify({ bestTime: 120, date: "2026-03-19" })
+    );
+    const result = updateTenPlayBestScore(90);
+    expect(result).toBe(true);
+  });
+
+  it("既存以上の時間なら更新しない", () => {
+    localStorageMock.setItem(
+      "ten-play-best-score",
+      JSON.stringify({ bestTime: 90, date: "2026-03-19" })
+    );
+    const result = updateTenPlayBestScore(120);
+    expect(result).toBe(false);
+  });
+
+  it("同じ時間では更新しない", () => {
+    localStorageMock.setItem(
+      "ten-play-best-score",
+      JSON.stringify({ bestTime: 90, date: "2026-03-19" })
+    );
+    const result = updateTenPlayBestScore(90);
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/ten-play-cards.ts
+++ b/src/lib/ten-play-cards.ts
@@ -1,0 +1,195 @@
+import type { PlayingCard, Suit, Rank } from "@/types/ten-play";
+
+/** スート一覧 */
+const SUITS: Suit[] = ["spade", "heart", "diamond", "club"];
+
+/** ランク一覧 */
+const RANKS: Rank[] = [
+  "A",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "J",
+  "Q",
+  "K",
+];
+
+/** テンプレイの各ランクに対応する値（A=1, J=11, Q=12, K=13） */
+const RANK_VALUES: Record<Rank, number> = {
+  A: 1,
+  "2": 2,
+  "3": 3,
+  "4": 4,
+  "5": 5,
+  "6": 6,
+  "7": 7,
+  "8": 8,
+  "9": 9,
+  "10": 10,
+  J: 11,
+  Q: 12,
+  K: 13,
+};
+
+/** スートの表示記号 */
+export const SUIT_SYMBOLS: Record<Suit, string> = {
+  spade: "♠",
+  heart: "♥",
+  diamond: "♦",
+  club: "♣",
+};
+
+/** スートの色（赤 or 黒） */
+export const SUIT_COLORS: Record<Suit, "red" | "black"> = {
+  spade: "black",
+  heart: "red",
+  diamond: "red",
+  club: "black",
+};
+
+/** タブローのスロット数 */
+export const TABLEAU_SIZE = 13;
+
+/** ペア除去の目標合計値 */
+export const TARGET_SUM = 10;
+
+/** 10のカードの値（単独除去対象） */
+export const SOLO_REMOVE_VALUE = 10;
+
+/**
+ * Fisher-Yatesアルゴリズムで配列をシャッフルする（元の配列は変更しない）
+ */
+export function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * 52枚のトランプデッキを生成してシャッフルする
+ */
+export function createDeck(): PlayingCard[] {
+  const cards: PlayingCard[] = [];
+  let id = 0;
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      cards.push({
+        id: id++,
+        suit,
+        rank,
+        value: RANK_VALUES[rank],
+      });
+    }
+  }
+  return shuffle(cards);
+}
+
+/**
+ * デッキからタブロー13枚と山札39枚に分割する
+ */
+export function buildTableau(deck: PlayingCard[]): {
+  tableau: (PlayingCard | null)[];
+  stock: PlayingCard[];
+} {
+  const tableau: (PlayingCard | null)[] = deck.slice(0, TABLEAU_SIZE);
+  const stock = deck.slice(TABLEAU_SIZE);
+  return { tableau, stock };
+}
+
+/**
+ * 2枚のカードが有効なペアかどうか判定する
+ * - 数札（A〜9）同士: 合計10
+ * - 同ランク絵札: J+J, Q+Q, K+K
+ */
+export function isValidPair(a: PlayingCard, b: PlayingCard): boolean {
+  // 数札同士で合計10
+  if (a.value <= 9 && b.value <= 9 && a.value + b.value === TARGET_SUM) {
+    return true;
+  }
+  // 同ランク絵札（J+J, Q+Q, K+K）
+  if (a.value >= 11 && b.value >= 11 && a.rank === b.rank) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * カードが単独除去可能か判定する（10のカード）
+ */
+export function isSoloRemovable(card: PlayingCard): boolean {
+  return card.value === SOLO_REMOVE_VALUE;
+}
+
+/**
+ * タブロー上の残りカード数を計算する
+ */
+export function getRemainingTableauCards(
+  tableau: (PlayingCard | null)[]
+): number {
+  return tableau.filter((c) => c !== null).length;
+}
+
+/**
+ * 全体の残りカード数を計算する（タブロー + 山札）
+ */
+export function getTotalRemainingCards(
+  tableau: (PlayingCard | null)[],
+  stock: PlayingCard[]
+): number {
+  return getRemainingTableauCards(tableau) + stock.length;
+}
+
+/**
+ * 手詰まりかどうか判定する
+ * タブローの非nullカード間に有効なペアがなく、単独除去可能な10もない場合
+ */
+export function isStuck(tableau: (PlayingCard | null)[]): boolean {
+  const cards = tableau.filter((c): c is PlayingCard => c !== null);
+
+  // 単独除去可能な10がある
+  if (cards.some((c) => isSoloRemovable(c))) return false;
+
+  // 有効なペアがある
+  for (let i = 0; i < cards.length; i++) {
+    for (let j = i + 1; j < cards.length; j++) {
+      if (isValidPair(cards[i], cards[j])) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * タブローの空きスロットに山札から補充する
+ */
+export function refillTableau(
+  tableau: (PlayingCard | null)[],
+  stock: PlayingCard[]
+): { tableau: (PlayingCard | null)[]; stock: PlayingCard[] } {
+  const newTableau = [...tableau];
+  const newStock = [...stock];
+
+  for (let i = 0; i < newTableau.length; i++) {
+    if (newTableau[i] === null && newStock.length > 0) {
+      newTableau[i] = newStock.shift()!;
+    }
+  }
+
+  return { tableau: newTableau, stock: newStock };
+}
+
+/**
+ * カードのラベルを取得する（アクセシビリティ用）
+ */
+export function getCardLabel(card: PlayingCard): string {
+  return `${SUIT_SYMBOLS[card.suit]}${card.rank}`;
+}

--- a/src/lib/ten-play-reducer.ts
+++ b/src/lib/ten-play-reducer.ts
@@ -1,0 +1,182 @@
+import type { TenPlayState, TenPlayAction } from "@/types/ten-play";
+import {
+  buildTableau,
+  isValidPair,
+  isSoloRemovable,
+  getRemainingTableauCards,
+  isStuck,
+  refillTableau,
+  TABLEAU_SIZE,
+} from "./ten-play-cards";
+
+/** ゲーム状態の初期値 */
+export const initialTenPlayState: TenPlayState = {
+  tableau: [],
+  stock: [],
+  selectedIndices: [],
+  removedCount: 0,
+  phase: "idle",
+  result: null,
+  elapsedTime: 0,
+  invalidPair: null,
+  isNewBest: false,
+  dialogOpen: false,
+};
+
+/** 除去→補充→クリア/手詰まり判定を行う共通処理 */
+function removeAndRefill(
+  state: TenPlayState,
+  indicesToRemove: number[]
+): TenPlayState {
+  // カードを除去（nullにする）
+  const newTableau = state.tableau.map((c, i) =>
+    indicesToRemove.includes(i) ? null : c
+  );
+  const newRemovedCount = state.removedCount + 1;
+
+  // 補充
+  const { tableau: refilledTableau, stock: newStock } = refillTableau(
+    newTableau,
+    state.stock
+  );
+
+  // クリア判定（タブロー上のカードが0枚かつ山札も0枚）
+  if (getRemainingTableauCards(refilledTableau) === 0 && newStock.length === 0) {
+    return {
+      ...state,
+      tableau: refilledTableau,
+      stock: newStock,
+      selectedIndices: [],
+      removedCount: newRemovedCount,
+      phase: "cleared",
+      result: "win",
+      invalidPair: null,
+      dialogOpen: true,
+    };
+  }
+
+  // 手詰まり判定
+  if (isStuck(refilledTableau)) {
+    return {
+      ...state,
+      tableau: refilledTableau,
+      stock: newStock,
+      selectedIndices: [],
+      removedCount: newRemovedCount,
+      phase: "stuck",
+      result: "lose",
+      invalidPair: null,
+      dialogOpen: true,
+    };
+  }
+
+  return {
+    ...state,
+    tableau: refilledTableau,
+    stock: newStock,
+    selectedIndices: [],
+    removedCount: newRemovedCount,
+    invalidPair: null,
+  };
+}
+
+/** テンプレイのゲーム状態を管理する純粋なReducer */
+export function tenPlayReducer(
+  state: TenPlayState,
+  action: TenPlayAction
+): TenPlayState {
+  switch (action.type) {
+    case "START_GAME": {
+      const { tableau, stock } = buildTableau(action.deck);
+
+      // 初期手詰まり判定
+      if (isStuck(tableau)) {
+        return {
+          ...initialTenPlayState,
+          tableau,
+          stock,
+          phase: "stuck",
+          result: "lose",
+          dialogOpen: true,
+        };
+      }
+
+      return {
+        ...initialTenPlayState,
+        tableau,
+        stock,
+        phase: "playing",
+      };
+    }
+
+    case "SELECT_CARD": {
+      if (state.phase !== "playing") return state;
+
+      const { index } = action;
+      if (index < 0 || index >= TABLEAU_SIZE) return state;
+
+      const card = state.tableau[index];
+      if (!card) return state;
+
+      // 既に選択済み → 選択解除
+      if (state.selectedIndices.includes(index)) {
+        return {
+          ...state,
+          selectedIndices: state.selectedIndices.filter((i) => i !== index),
+        };
+      }
+
+      // 10のカード → 単独除去
+      if (isSoloRemovable(card)) {
+        return removeAndRefill(state, [index]);
+      }
+
+      // 1枚目の選択
+      if (state.selectedIndices.length === 0) {
+        return {
+          ...state,
+          selectedIndices: [index],
+        };
+      }
+
+      // 2枚目の選択 → ペア判定
+      const firstIndex = state.selectedIndices[0];
+      const firstCard = state.tableau[firstIndex];
+      if (!firstCard) return state;
+
+      if (isValidPair(firstCard, card)) {
+        // ペア除去成功
+        return removeAndRefill(state, [firstIndex, index]);
+      }
+
+      // 不正ペア
+      return {
+        ...state,
+        invalidPair: [firstIndex, index],
+        selectedIndices: [],
+      };
+    }
+
+    case "CLEAR_INVALID":
+      return {
+        ...state,
+        invalidPair: null,
+      };
+
+    case "TICK":
+      if (state.phase !== "playing") return state;
+      return { ...state, elapsedTime: state.elapsedTime + 1 };
+
+    case "SET_NEW_BEST":
+      return { ...state, isNewBest: action.isNewBest };
+
+    case "DISMISS_DIALOG":
+      return { ...state, dialogOpen: false };
+
+    case "RESTART":
+      return initialTenPlayState;
+
+    default:
+      return state;
+  }
+}

--- a/src/lib/ten-play-storage.ts
+++ b/src/lib/ten-play-storage.ts
@@ -1,0 +1,43 @@
+import type { TenPlayBestScore } from "@/types/ten-play";
+
+const STORAGE_KEY = "ten-play-best-score";
+
+/** ベストスコアをlocalStorageから取得する */
+export function getTenPlayBestScore(): TenPlayBestScore | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    if (!data) return null;
+    return JSON.parse(data) as TenPlayBestScore;
+  } catch {
+    return null;
+  }
+}
+
+/** ベストスコアをlocalStorageに保存する */
+export function saveTenPlayBestScore(score: TenPlayBestScore): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(score));
+  } catch {
+    // localStorageが使用できない場合は何もしない
+  }
+}
+
+/**
+ * クリア時間がベストを更新するか判定し、更新する場合は保存する
+ * 判定基準: bestTime が既存より短ければ更新
+ */
+export function updateTenPlayBestScore(elapsedTime: number): boolean {
+  const current = getTenPlayBestScore();
+
+  if (!current || elapsedTime < current.bestTime) {
+    saveTenPlayBestScore({
+      bestTime: elapsedTime,
+      date: new Date().toISOString().split("T")[0],
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/types/ten-play.ts
+++ b/src/types/ten-play.ts
@@ -1,0 +1,78 @@
+/** トランプのスート */
+export type Suit = "spade" | "heart" | "diamond" | "club";
+
+/** トランプのランク */
+export type Rank =
+  | "A"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9"
+  | "10"
+  | "J"
+  | "Q"
+  | "K";
+
+/** トランプカード1枚 */
+export type PlayingCard = {
+  /** 一意のID */
+  id: number;
+  /** スート */
+  suit: Suit;
+  /** ランク表示 */
+  rank: Rank;
+  /** 数値（A=1, 2-10=そのまま, J=11, Q=12, K=13） */
+  value: number;
+};
+
+/** ゲームのフェーズ */
+export type TenPlayPhase = "idle" | "playing" | "cleared" | "stuck";
+
+/** ゲーム結果 */
+export type TenPlayGameResult = "win" | "lose";
+
+/** ゲームの状態 */
+export type TenPlayState = {
+  /** タブローのカード（13スロット、null=空） */
+  tableau: (PlayingCard | null)[];
+  /** 山札（初期39枚） */
+  stock: PlayingCard[];
+  /** 選択中のタブローインデックス */
+  selectedIndices: number[];
+  /** 除去回数 */
+  removedCount: number;
+  /** ゲームのフェーズ */
+  phase: TenPlayPhase;
+  /** ゲーム結果 */
+  result: TenPlayGameResult | null;
+  /** 経過時間（秒） */
+  elapsedTime: number;
+  /** 不正ペアインデックス（アニメ用） */
+  invalidPair: number[] | null;
+  /** 新記録かどうか */
+  isNewBest: boolean;
+  /** ダイアログの表示状態 */
+  dialogOpen: boolean;
+};
+
+/** ベストスコア */
+export type TenPlayBestScore = {
+  /** 最短クリア時間（秒） */
+  bestTime: number;
+  /** 記録日 */
+  date: string;
+};
+
+/** Reducerアクション */
+export type TenPlayAction =
+  | { type: "START_GAME"; deck: PlayingCard[] }
+  | { type: "SELECT_CARD"; index: number }
+  | { type: "CLEAR_INVALID" }
+  | { type: "TICK" }
+  | { type: "SET_NEW_BEST"; isNewBest: boolean }
+  | { type: "DISMISS_DIALOG" }
+  | { type: "RESTART" };


### PR DESCRIPTION
Closes #69

## Summary

- 合計10になるペアを除去するソリティアゲームを追加
- 10のカードは単独除去、絵札（J/Q/K）は同ランクペアで除去
- タブロー13スロット（7+6の2段構成）に配置し、除去後は山札から補充
- クリア時の最短タイムをベストスコアとして記録（手詰まりは対象外）

## Test plan

- [ ] ホーム画面にテンプレイが表示される
- [ ] ゲーム開始でタブローに13枚配置される
- [ ] カード選択 → ペア除去 → 山札から補充される
- [ ] 10のカードを選択すると単独除去される
- [ ] 同ランク絵札（J+J, Q+Q, K+K）がペア除去される
- [ ] 不正ペア選択時に赤くハイライトされ、500ms後に解除される
- [ ] クリア時にダイアログが表示され、タイムが記録される
- [ ] 手詰まり時にダイアログが表示される（ベストスコアは更新されない）
- [ ] ベストスコアはMM:SS形式で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)