### PR TITLE
chore: OS通知フックをsettings.local.jsonからsettings.jsonへ移動

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,16 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude が入力を待っています\" with title \"Claude Code\"'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- `settings.local.json` の `Notification` フック（OS通知）を `settings.json` へ移動
- OS通知はチーム共有可能な設定のため、リポジトリ管理の `settings.json` で管理する

## Test plan

- [ ] `settings.json` に `Notification` フックが追加されていること
- [ ] Claude Code のセッション終了時に OS通知（「Claude が入力を待っています」）が表示されること

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)