### PR TITLE
chore: Notification フックに permission_prompt matcher を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,7 @@
     ],
     "Notification": [
       {
+        "matcher": "permission_prompt",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- `settings.json` の `Notification` フックに `"matcher": "permission_prompt"` を追加
- ツール承認ダイアログ（permission_prompt）表示時のみ OS 通知が発火するよう絞り込み
- 承認不要なツール（Read 等）での不要な通知を抑制

## Test plan

- [ ] Edit/Write/Bash 等でツール承認ダイアログが出る際に macOS 通知「Claude が入力を待っています」が表示されること
- [ ] 承認不要なツール（Read 等）では通知が出ないこと

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)