### PR TITLE
chore: shared-claude-rules の新規スキルのシンボリックリンクを追加

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -277,7 +277,9 @@ WarBoard → useWar
 | docs-sync | `/docs-sync` | ソースコードの実態とドキュメント（README.md, CLAUDE.md, architecture.md）の整合性を検証・更新 |
 | game-debug | `/game-debug [ゲーム名]` | ゲームの reducer を対話的に操作し、状態遷移をデバッグする |
 | game-refactor | `/game-refactor [ゲーム名]` | 指定ゲーム（または全ゲーム）の規約準拠チェック＋自動リファクタリング |
+| config-shared-sync | `/config-shared-sync` | shared-claude-rules から共有ルール・スキルのシンボリックリンクを同期 |
 | git-branch-cleanup | `/git-branch-cleanup` | PR マージ後にローカルの feature ブランチを削除し、main を最新化する |
+| git-issue-create | `/git-issue-create` | 会話コンテキストから GitHub Issue を作成 |
 | git-issue-start | `/git-issue-start [Issue番号]` | GitHub Issue を取得し、ブランチ作成。ゲーム追加 Issue は実装も開始 |
 | git-pr-create | `/git-pr-create [コミットメッセージ]` | feature ブランチのコミット・プッシュ・PR 作成を一括実行 |
 | git-review-respond | `/git-review-respond [PR番号]` | PR レビューコメントのトリアージ→修正→品質チェック→プッシュ→返信を一括実行 |

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -22,7 +22,9 @@ Audits games for adherence to project conventions and automatically refactors an
 
 ## Shared Skills (symlinks → shared-claude-rules)
 
+- `/config-shared-sync` — Syncs shared rules and skills symlinks from shared-claude-rules
 - `/git-branch-cleanup` — Cleans up after a PR merge
+- `/git-issue-create` — Creates a GitHub Issue from conversation context
 - `/git-issue-start [issue-number]` — Fetches a GitHub Issue and creates a feature branch
 - `/git-pr-create [commit-message]` — Commits, pushes, and creates a PR
 - `/git-review-respond [pr-number]` — Handles PR review comments end-to-end

--- a/.claude/skills/config-shared-sync
+++ b/.claude/skills/config-shared-sync
@@ -1,0 +1,1 @@
+../../../shared-claude-rules/skills/config-shared-sync

--- a/.claude/skills/git-issue-create
+++ b/.claude/skills/git-issue-create
@@ -1,0 +1,1 @@
+../../../shared-claude-rules/skills/git-issue-create


### PR DESCRIPTION
## Summary
- `config-shared-sync` と `git-issue-create` のシンボリックリンクを `.claude/skills/` に追加
- `skills/README.md` と `architecture.md` のスキル一覧を更新

Closes #115

## Test plan
- [ ] シンボリックリンクが正しく解決されることを確認
- [ ] `/config-shared-sync` と `/git-issue-create` が Claude Code から呼び出せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)