### PR TITLE
enhance: READMEに多言語対応（英語・日本語切り替え）を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Language:** English | [日本語](docs/ja-JP/README.md)
+
 # Card Games
 
 A web app where you can play various card games.

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -1,0 +1,32 @@
+**Language:** [English](../../README.md) | 日本語
+
+# カードゲーム
+
+さまざまなカードゲームをブラウザで楽しめる Web アプリです。
+
+> **Note:** このプロジェクトは [Claude Code](https://claude.ai/code) の練習として作成されました。コーディングはすべて Claude Code が行い、人間はレビューとフィードバックのみを担当しています。
+
+## ゲーム一覧
+
+神経衰弱 / ハイ＆ロー / ブラックジャック / ビデオポーカー / ピラミッド / ゴルフソリテア / スパイダー / テンプレイ / トライピークス / ウォー
+
+## 技術スタック
+
+- Next.js (App Router)
+- TypeScript
+- Tailwind CSS 4
+- shadcn/ui
+- Vitest
+
+## セットアップ
+
+```bash
+npm install
+npm run dev
+```
+
+## ドキュメント
+
+- [アーキテクチャ](../../.claude/rules/architecture.md) — ゲーム構成、ルーティング、コンポーネントツリー
+- [コーディング規約](../../.claude/rules/conventions.md) — コーディングルール、デザイン要件、ワークフロー
+- [CLAUDE.md](../../CLAUDE.md) — コマンド、スキル、エージェント


### PR DESCRIPTION
## Summary

- `README.md` 冒頭に `**Language:**` セクションを追加し、日本語版READMEへのリンクを記載
- `docs/ja-JP/README.md` を新規作成し、英語版READMEの日本語訳を整備

Closes #126

## Test plan

- [ ] `README.md` 冒頭に `**Language:** English | 日本語` が表示されている
- [ ] `docs/ja-JP/README.md` が存在し、日本語で内容が記載されている
- [ ] 相互リンクが正しく機能する（英語版↔日本語版の遷移）

🤖 Generated with [Claude Code](https://claude.com/claude-code)