### PR TITLE
chore: シンボリックリンク先をshared-claude-rulesからshared-claude-codeに更新する

### DIFF
--- a/.claude/rules/shared/conventions.md
+++ b/.claude/rules/shared/conventions.md
@@ -1,1 +1,1 @@
-../../../../shared-claude-rules/rules/conventions.md
+../../../../shared-claude-code/rules/conventions.md

--- a/.claude/rules/shared/security.md
+++ b/.claude/rules/shared/security.md
@@ -1,1 +1,1 @@
-../../../../shared-claude-rules/rules/security.md
+../../../../shared-claude-code/rules/security.md

--- a/.claude/skills/config-claude-sync
+++ b/.claude/skills/config-claude-sync
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/config-claude-sync
+../../../shared-claude-code/skills/config-claude-sync

--- a/.claude/skills/config-github-sync
+++ b/.claude/skills/config-github-sync
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/config-github-sync
+../../../shared-claude-code/skills/config-github-sync

--- a/.claude/skills/git-branch-cleanup
+++ b/.claude/skills/git-branch-cleanup
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/git-branch-cleanup
+../../../shared-claude-code/skills/git-branch-cleanup

--- a/.claude/skills/git-issue-create
+++ b/.claude/skills/git-issue-create
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/git-issue-create
+../../../shared-claude-code/skills/git-issue-create

--- a/.claude/skills/git-issue-start
+++ b/.claude/skills/git-issue-start
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/git-issue-start
+../../../shared-claude-code/skills/git-issue-start

--- a/.claude/skills/git-pr-create
+++ b/.claude/skills/git-pr-create
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/git-pr-create
+../../../shared-claude-code/skills/git-pr-create

--- a/.claude/skills/git-review-respond
+++ b/.claude/skills/git-review-respond
@@ -1,1 +1,1 @@
-../../../shared-claude-rules/skills/git-review-respond
+../../../shared-claude-code/skills/git-review-respond


### PR DESCRIPTION
## Summary

- `.claude/rules/shared/` および `.claude/skills/` 配下の9つのシンボリックリンクを `shared-claude-rules` → `shared-claude-code` に更新

## 変更対象

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `.claude/rules/shared/conventions.md` | `shared-claude-rules/rules/conventions.md` | `shared-claude-code/rules/conventions.md` |
| `.claude/rules/shared/security.md` | `shared-claude-rules/rules/security.md` | `shared-claude-code/rules/security.md` |
| `.claude/skills/config-claude-sync` | `shared-claude-rules/skills/...` | `shared-claude-code/skills/...` |
| `.claude/skills/config-github-sync` | 〃 | 〃 |
| `.claude/skills/git-branch-cleanup` | 〃 | 〃 |
| `.claude/skills/git-issue-create` | 〃 | 〃 |
| `.claude/skills/git-issue-start` | 〃 | 〃 |
| `.claude/skills/git-pr-create` | 〃 | 〃 |
| `.claude/skills/git-review-respond` | 〃 | 〃 |

closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)