### PR TITLE
enhance: カスタム404ページ（not-found.tsx）を追加する

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="game-background flex flex-col items-center justify-center px-4 py-10 sm:py-16">
+      <div className="glass rounded-2xl p-8 shadow-lg w-full max-w-md text-center">
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-800">
+          ページが見つかりません
+        </h1>
+        <p className="text-sm text-gray-500 mt-3">
+          お探しのページは存在しないか、移動した可能性があります。URLをご確認ください。
+        </p>
+        <div className="flex justify-center mt-6">
+          <Button variant="outline" asChild>
+            <Link href="/">ホームに戻る</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- プロジェクトのデザインシステム（glassmorphism、gradient background）に準拠したカスタム404ページを追加
- 既存の `error.tsx` と統一されたレイアウト・スタイルパターンを採用
- 「ホームに戻る」ボタンでホーム画面への導線を提供

Closes #143

## Test plan
- [ ] `npm run lint` パス
- [ ] `npm run test` パス
- [ ] `npm run build` パス
- [ ] `npm run dev` → `/nonexistent` にアクセスしカスタム404ページが表示されることを確認
- [ ] 「ホームに戻る」ボタンでホーム画面に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)