### PR TITLE
enhance: stock/waste pileボタンのaria-labelを改善する

### DIFF
--- a/src/components/golf/golf-stock-area.tsx
+++ b/src/components/golf/golf-stock-area.tsx
@@ -34,7 +34,7 @@ export function GolfStockArea({
             )}
             onClick={canDraw ? onDraw : undefined}
             disabled={!canDraw}
-            aria-label={`山札（残り${stock.length}枚）`}
+            aria-label={`山札からカードを引く（残り${stock.length}枚）`}
           >
             <div className="card-inner w-full h-full">
               <div
@@ -51,7 +51,10 @@ export function GolfStockArea({
             </div>
           </button>
         ) : (
-          <div className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="山札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}
@@ -63,7 +66,10 @@ export function GolfStockArea({
         {wasteTop ? (
           <GolfCard card={wasteTop} />
         ) : (
-          <div className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="捨て札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}

--- a/src/components/pyramid/pyramid-stock-area.tsx
+++ b/src/components/pyramid/pyramid-stock-area.tsx
@@ -39,7 +39,7 @@ export function PyramidStockArea({
             type="button"
             className="card-container w-14 h-20 sm:w-16 sm:h-22 cursor-pointer select-none"
             onClick={onDrawStock}
-            aria-label={`山札（残り${stock.length}枚）`}
+            aria-label={`山札からカードを引く（残り${stock.length}枚）`}
           >
             <div className="card-inner w-full h-full">
               <div
@@ -60,12 +60,15 @@ export function PyramidStockArea({
             type="button"
             className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-300 flex items-center justify-center cursor-pointer select-none hover:border-gray-400 transition-colors"
             onClick={onRecycleStock}
-            aria-label="山札をリサイクル"
+            aria-label="捨て札を山札にリサイクルする"
           >
             <span className="text-xl text-gray-400">↻</span>
           </button>
         ) : (
-          <div className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="山札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}
@@ -83,7 +86,10 @@ export function PyramidStockArea({
             onClick={() => onSelectWaste(wasteTop.id)}
           />
         ) : (
-          <div className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="捨て札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}

--- a/src/components/spider/spider-stock-area.tsx
+++ b/src/components/spider/spider-stock-area.tsx
@@ -34,7 +34,7 @@ export function SpiderStockArea({
             )}
             onClick={canDeal ? onDeal : undefined}
             disabled={!canDeal}
-            aria-label={`山札（残り${remainingSets}回配布可能）`}
+            aria-label={`山札から各列にカードを配る（残り${remainingSets}回）`}
           >
             <div className="card-inner w-full h-full">
               <div
@@ -51,7 +51,10 @@ export function SpiderStockArea({
             </div>
           </button>
         ) : (
-          <div className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-14 h-20 sm:w-16 sm:h-22 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="山札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}

--- a/src/components/tri-peaks/tri-peaks-stock-area.tsx
+++ b/src/components/tri-peaks/tri-peaks-stock-area.tsx
@@ -34,7 +34,7 @@ export function TriPeaksStockArea({
             )}
             onClick={canDraw ? onDraw : undefined}
             disabled={!canDraw}
-            aria-label={`山札（残り${stock.length}枚）`}
+            aria-label={`山札からカードを引く（残り${stock.length}枚）`}
           >
             <div className="card-inner w-full h-full">
               <div
@@ -51,7 +51,10 @@ export function TriPeaksStockArea({
             </div>
           </button>
         ) : (
-          <div className="w-10 h-14 sm:w-12 sm:h-16 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-10 h-14 sm:w-12 sm:h-16 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="山札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}
@@ -63,7 +66,10 @@ export function TriPeaksStockArea({
         {wasteTop ? (
           <TriPeaksCard card={wasteTop} />
         ) : (
-          <div className="w-10 h-14 sm:w-12 sm:h-16 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center">
+          <div
+            className="w-10 h-14 sm:w-12 sm:h-16 rounded-2xl border-2 border-dashed border-gray-200 flex items-center justify-center"
+            aria-label="捨て札（空）"
+          >
             <span className="text-xs text-gray-300">空</span>
           </div>
         )}


### PR DESCRIPTION
## Summary
- stock pileボタンのaria-labelに操作内容（「カードを引く」「各列にカードを配る」等）を追加
- stock/waste pileが空のときのプレースホルダーにaria-labelを追加
- Pyramid のリサイクルボタンのaria-labelを操作対象が明確な表現に改善

Closes #144

## Test plan
- [ ] 各ゲーム（Golf, Pyramid, Spider, Tri Peaks）でstock pileのボタンをスクリーンリーダーで確認
- [ ] stock/wasteが空の状態でaria-labelが読み上げられることを確認
- [ ] Pyramidのリサイクルボタンのaria-labelを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)